### PR TITLE
Volume and SSH fixes

### DIFF
--- a/src/dcos_e2e/backends/_dcos_docker/__init__.py
+++ b/src/dcos_e2e/backends/_dcos_docker/__init__.py
@@ -183,6 +183,8 @@ class DCOS_Docker_Cluster(ClusterManager):  # pylint: disable=invalid-name
 
         master_mounts = []
         for host_path, master_path in files_to_copy_to_masters.items():
+            # The volume is mounter `rw` because certain processes change the
+            # content or permission of the files on the volume.
             mount = '-v {host_path}:{master_path}:rw'.format(
                 host_path=host_path.absolute(),
                 master_path=master_path,

--- a/src/dcos_e2e/backends/_dcos_docker/__init__.py
+++ b/src/dcos_e2e/backends/_dcos_docker/__init__.py
@@ -183,7 +183,7 @@ class DCOS_Docker_Cluster(ClusterManager):  # pylint: disable=invalid-name
 
         master_mounts = []
         for host_path, master_path in files_to_copy_to_masters.items():
-            mount = '-v {host_path}:{master_path}:ro'.format(
+            mount = '-v {host_path}:{master_path}:rw'.format(
                 host_path=host_path.absolute(),
                 master_path=master_path,
             )

--- a/src/dcos_e2e/backends/_dcos_docker/__init__.py
+++ b/src/dcos_e2e/backends/_dcos_docker/__init__.py
@@ -183,8 +183,8 @@ class DCOS_Docker_Cluster(ClusterManager):  # pylint: disable=invalid-name
 
         master_mounts = []
         for host_path, master_path in files_to_copy_to_masters.items():
-            # The volume is mounter `rw` because certain processes change the
-            # content or permission of the files on the volume.
+            # The volume is mounted `read-write` because certain processes
+            # change the content or permission of the files on the volume.
             mount = '-v {host_path}:{master_path}:rw'.format(
                 host_path=host_path.absolute(),
                 master_path=master_path,

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -63,9 +63,10 @@ class Node:
             # In particular, we don't care about remote host identification
             # changes.
             '-q',
-            # This makes sure that only keys passed wih the -i option are used.
-            # Needed when there are already keys present in the SSH keychain,
-            # which cause `Error: Too many Authentication Failures`.
+            # This makes sure that only keys passed with the -i option are
+            # used. Needed when there are already keys present in the SSH
+            # key chain, which cause `Error: Too many Authentication
+            # Failures`.
             '-o',
             'IdentitiesOnly=yes',
             # The node may be an unknown host.

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -64,6 +64,8 @@ class Node:
             # changes.
             '-q',
             # This makes sure that only keys passed wih the -i option are used.
+            # Needed when there are already keys present in the SSH keychain,
+            # which cause `Error: Too many Authentication Failures`.
             '-o',
             'IdentitiesOnly=yes',
             # The node may be an unknown host.

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -63,6 +63,9 @@ class Node:
             # In particular, we don't care about remote host identification
             # changes.
             '-q',
+            # This makes sure that only keys passed wih the -i option are used.
+            '-o',
+            'IdentitiesOnly=yes',
             # The node may be an unknown host.
             '-o',
             'StrictHostKeyChecking=no',


### PR DESCRIPTION
* Mount volume needed for `files_to_copy_to_masters` in `rw` mode.
* Add `-o IdentitiesOnly=yes` to the SSH command. This makes sure that the keys already present in the keychain are ignored and only the ones passed with the `-i` option are used.