### PR TITLE
[WIP] Replaced generate_config_path with url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,30 @@ env:
   # per commit.
   # We run almost one builder per test.
   matrix:
-      - "TEST_PATTERN=tests/test_enterprise.py::TestEnterpriseIntegrationTests::test_run_pytest"
-      - "TEST_PATTERN=tests/test_enterprise.py::TestWaitForDCOS::test_auth_with_cli"
-      - "TEST_PATTERN=tests/test_enterprise.py::TestCopyFiles::test_copy_files_to_installer"
+      # - "TEST_PATTERN=tests/test_enterprise.py::TestEnterpriseIntegrationTests::test_run_pytest"
+      # - "TEST_PATTERN=tests/test_enterprise.py::TestWaitForDCOS::test_auth_with_cli"
+      # - "TEST_PATTERN=tests/test_enterprise.py::TestCopyFiles::test_copy_files_to_installer"
       # This test class uses one scoped cluster so we run it on one builder.
-      - "TEST_PATTERN=tests/test_node.py::TestNode"
-      - "TEST_PATTERN=tests/test_harness.py::TestIntegrationTests::test_run_pytest"
-      - "TEST_PATTERN=tests/test_harness.py::TestExtendConfig::test_extend_config"
-      - "TEST_PATTERN=tests/test_harness.py::TestExtendConfig::test_default_config"
-      - "TEST_PATTERN=tests/test_harness.py::TestClusterSize::test_default"
-      - "TEST_PATTERN=tests/test_harness.py::TestClusterSize::test_custom"
-      - "TEST_PATTERN=tests/test_harness.py::TestClusterLogging::test_live_logging"
-      - "TEST_PATTERN=tests/test_harness.py::TestClusterLogging::test_no_live_logging"
-      - "TEST_PATTERN=tests/test_harness.py::TestMultipleClusters::test_two_clusters"
-      - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnError::test_default_exception_raised"
-      - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnError::test_set_false_exception_raised"
-      - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnSuccess::test_default"
-      - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnSuccess::test_false"
-      - "TEST_PATTERN=tests/backends/test_docker.py::TestCustomMasterMounts::test_custom_master_mounts"
-      - "TEST_PATTERN=tests/backends/test_existing_cluster.py::TestExistingCluster::test_existing_cluster"
+      # - "TEST_PATTERN=tests/test_node.py::TestNode"
+      # - "TEST_PATTERN=tests/test_harness.py::TestIntegrationTests::test_run_pytest"
+      # - "TEST_PATTERN=tests/test_harness.py::TestExtendConfig::test_extend_config"
+      # - "TEST_PATTERN=tests/test_harness.py::TestExtendConfig::test_default_config"
+      # - "TEST_PATTERN=tests/test_harness.py::TestClusterSize::test_default"
+      # - "TEST_PATTERN=tests/test_harness.py::TestClusterSize::test_custom"
+      # - "TEST_PATTERN=tests/test_harness.py::TestClusterLogging::test_live_logging"
+      # - "TEST_PATTERN=tests/test_harness.py::TestClusterLogging::test_no_live_logging"
+      # - "TEST_PATTERN=tests/test_harness.py::TestMultipleClusters::test_two_c
+      # lusters"
+      # - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnError::test_default_exception_raised"
+      # - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnError::test_set_false_exception_raised"
+      # - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnSuccess::test_default"
+      # - "TEST_PATTERN=tests/test_harness.py::TestDestroyOnSuccess::test_false"
+      # - "TEST_PATTERN=tests/backends/test_docker.py::TestCustomMasterMounts::test_custom_master_mounts"
+      - "TEST_PATTERN=tests/backends/test_docker.py::TestRemoteBuildArtifact::test_local_build_artifact"
+      - "TEST_PATTERN=tests/backends/test_docker.py::TestRemoteBuildArtifact::test_remote_build_artifact"
+      # - "TEST_PATTERN=tests/backends/test_existing_cluster.py::TestExistingCluster::test_existing_cluster"
       # This test class uses one scoped cluster so we run it on one builder.
-      - "TEST_PATTERN=tests/backends/test_existing_cluster.py::TestBadParameters"
+      # - "TEST_PATTERN=tests/backends/test_existing_cluster.py::TestBadParameters"
   global:
     # The encrypted URL for a DC/OS Enterprise artifact.
     # Generate this by running:

--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@
 - [`dcos_e2e.cluster.Cluster`](#dcos_e2eclustercluster)
   - [Parameters](#parameters)
     - [`cluster_backend`](#cluster_backend)
-    - [`generate_config_path`](#generate_config_path)
+    - [`generate_config_url`](#generate_config_url)
     - [`extra_config`](#extra_config)
     - [`masters`](#masters)
     - [`agents`](#agents)
@@ -48,7 +48,7 @@
 ```python
 Cluster(
     cluster_backend,
-    generate_config_path=None,
+    generate_config_url=None,
     extra_config=None,
     masters=1,
     agents=1,
@@ -69,9 +69,9 @@ This is a context manager which spins up a cluster.
 The backend to use for the cluster.
 See [`BACKENDS.md`](./BACKENDS.md) for details.
 
-#### `generate_config_path`
+#### `generate_config_url`
 
-The path to a build artifact to install.
+The url to a build artifact to install.
 
 #### `extra_config`
 

--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -78,7 +78,7 @@ ExistingCluster(masters, agents, public_agents)
 ```
 
 When creating a `Cluster` with this backend, the following parameter conditions must be true:
-* `generate_config_path` must be `None`,
+* `generate_config_url` must be `None`,
 * `extra_config` must be `None` or `{}`,
 * `masters` matches the number of master nodes in the existing cluster,
 * `agents` matches the number of agent nodes in the existing cluster,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [Changelog](#changelog)
   - [Next](#next)
+  - [2017.11.06.0](#201711060)
   - [2017.11.02.0](#201711020)
   - [2017.10.04.0](#201710040)
   - [2017.08.11.0](#201708110)
@@ -28,6 +29,11 @@
 ## Next
 
 * Backwards incompatible change: Rename `DCOS_Docker` backend to `Docker` backend.
+
+## 2017.11.06.0
+
+* Replaced `generate_config_path` with `generate_config_url` to allow for supporting
+installation methods that require build artifacts to be downloaded via HTTP.
 
 ## 2017.11.02.0
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Then, create a test, such as the following:
 
 ```python
 import subprocess
-from pathlib import Path
 
 from dcos_e2e.backends import Docker
 from dcos_e2e.cluster import Cluster
@@ -52,7 +51,7 @@ class TestExample:
         with Cluster(
             extra_config={'check_time': True},
             cluster_backend=Docker(),
-            generate_config_path=Path('/tmp/dcos_generate_config.sh'),
+            generate_config_url=Path('file:///tmp/dcos_generate_config.sh'),
         ) as cluster:
             (master, ) = cluster.masters
             result = master.run_as_root(args=['test', '-f', path])

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -7,6 +7,7 @@ from contextlib import ContextDecorator
 from pathlib import Path
 from time import sleep
 from typing import Any, Dict, Iterable, List, Optional, Set
+from urllib.parse import urlparse
 
 import requests
 from requests import codes
@@ -28,7 +29,7 @@ class Cluster(ContextDecorator):
     def __init__(
         self,
         cluster_backend: ClusterBackend,
-        generate_config_path: Path = None,
+        generate_config_url: str = None,
         extra_config: Optional[Dict[str, Any]] = None,
         masters: int = 1,
         agents: int = 1,
@@ -43,7 +44,8 @@ class Cluster(ContextDecorator):
 
         Args:
             cluster_backend: The backend to use for the cluster.
-            generate_config_path: The path to a build artifact to install.
+            generate_config_url: The url to a build artifact to install.
+                Supported url types may vary between implementations.
             extra_config: This dictionary can contain extra installation
                 configuration variables to add to base configurations.
             masters: The number of master nodes to create.
@@ -77,6 +79,9 @@ class Cluster(ContextDecorator):
             )
             raise ValueError(message)
 
+        if generate_config_url:
+            urlparse(generate_config_url)
+
         self._destroy_on_error = destroy_on_error
         self._destroy_on_success = destroy_on_success
         self._log_output_live = log_output_live
@@ -90,7 +95,7 @@ class Cluster(ContextDecorator):
             log_output_live=self._log_output_live,
             files_to_copy_to_installer=dict(files_to_copy_to_installer or {}),
             cluster_backend=cluster_backend,
-            generate_config_path=generate_config_path,
+            generate_config_url=generate_config_url,
         )  # type: ClusterManager
 
     @retry(

--- a/tests/backends/test_docker.py
+++ b/tests/backends/test_docker.py
@@ -21,7 +21,7 @@ class TestCustomMasterMounts:
     def test_custom_master_mounts(
         self,
         tmpdir: local,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         It is possible to mount local files to master nodes.
@@ -40,7 +40,7 @@ class TestCustomMasterMounts:
 
         with Cluster(
             cluster_backend=backend,
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             masters=1,
             agents=0,
             public_agents=0,
@@ -54,3 +54,41 @@ class TestCustomMasterMounts:
             local_file.write(new_content)
             result = master.run_as_root(args=args)
             assert result.stdout.decode() == new_content
+
+
+class TestLocalBuildArtifact:
+    """
+    Tests for build artifact located on a HTTPS server.
+    """
+
+    def test_remote_build_artifact(
+        self, tmpdir: local, oss_artifact: str
+    ) -> None:
+
+        with Cluster(
+            cluster_backend=Docker(workspace_dir=tmpdir),
+            generate_config_url=oss_artifact,
+            masters=1,
+            agents=0,
+            public_agents=0,
+        ):
+            pass
+
+
+class TestRemoteBuildArtifact:
+    """
+    Tests for build artifact located on a HTTPS server.
+    """
+
+    def test_remote_build_artifact(
+        self, tmpdir: local, oss_artifact_url: str
+    ) -> None:
+
+        with Cluster(
+            cluster_backend=Docker(workspace_dir=tmpdir),
+            generate_config_url=oss_artifact_url,
+            masters=1,
+            agents=0,
+            public_agents=0,
+        ):
+            pass

--- a/tests/backends/test_existing_cluster.py
+++ b/tests/backends/test_existing_cluster.py
@@ -16,14 +16,14 @@ class TestExistingCluster:
     Tests for creating a `Cluster` with the `ExistingCluster` backend.
     """
 
-    def test_existing_cluster(self, oss_artifact: Path) -> None:
+    def test_existing_cluster(self, oss_artifact: str) -> None:
         """
         It is possible to create a cluster from existing nodes, but not destroy
         it.
         """
         with Cluster(
             cluster_backend=Docker(),
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             masters=1,
             agents=1,
             public_agents=1,
@@ -84,7 +84,7 @@ class TestBadParameters:
     """
 
     @pytest.fixture(scope='module')
-    def dcos_cluster(self, oss_artifact: Path) -> Iterator[Cluster]:
+    def dcos_cluster(self, oss_artifact: str) -> Iterator[Cluster]:
         """
         Return a `Cluster`.
 
@@ -92,7 +92,7 @@ class TestBadParameters:
         """
         with Cluster(
             cluster_backend=Docker(),
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             masters=1,
             agents=0,
             public_agents=0,
@@ -221,7 +221,7 @@ class TestBadParameters:
     def test_installer_file(
         self,
         dcos_cluster: Cluster,
-        oss_artifact: Path,
+        oss_artifact: str,
         existing_cluster_backend: ClusterBackend,
     ) -> None:
         """
@@ -230,7 +230,7 @@ class TestBadParameters:
         with pytest.raises(ValueError) as excinfo:
             with Cluster(
                 cluster_backend=existing_cluster_backend,
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
                 masters=len(dcos_cluster.masters),
                 agents=len(dcos_cluster.agents),
                 public_agents=len(dcos_cluster.public_agents),
@@ -241,7 +241,7 @@ class TestBadParameters:
 
         expected_error = (
             'Cluster already exists with DC/OS installed. '
-            'Therefore, `generate_config_path` must be `None`.'
+            'Therefore, `generate_config_url` must be `None`.'
         )
 
         assert str(excinfo.value) == expected_error
@@ -257,7 +257,7 @@ class TestBadParameters:
         with pytest.raises(ValueError) as excinfo:
             with Cluster(
                 cluster_backend=existing_cluster_backend,
-                generate_config_path=None,
+                generate_config_url=None,
                 masters=len(dcos_cluster.masters) + 2,
                 agents=len(dcos_cluster.agents),
                 public_agents=len(dcos_cluster.public_agents),
@@ -284,7 +284,7 @@ class TestBadParameters:
         with pytest.raises(ValueError) as excinfo:
             with Cluster(
                 cluster_backend=existing_cluster_backend,
-                generate_config_path=None,
+                generate_config_url=None,
                 masters=len(dcos_cluster.masters),
                 agents=len(dcos_cluster.agents) + 1,
                 public_agents=len(dcos_cluster.public_agents),
@@ -312,7 +312,7 @@ class TestBadParameters:
         with pytest.raises(ValueError) as excinfo:
             with Cluster(
                 cluster_backend=existing_cluster_backend,
-                generate_config_path=None,
+                generate_config_url=None,
                 masters=len(dcos_cluster.masters),
                 agents=len(dcos_cluster.agents),
                 public_agents=len(dcos_cluster.public_agents) + 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@
 Helpers for running tests with `pytest`.
 """
 
-from pathlib import Path
-
 import pytest
 
 from dcos_e2e.backends import ClusterBackend, Docker
@@ -18,16 +16,24 @@ def cluster_backend() -> ClusterBackend:
 
 
 @pytest.fixture(scope='session')
-def oss_artifact() -> Path:
+def oss_artifact() -> str:
     """
-    Return the path to an artifact for DC/OS OSS.
+    Return the url to a local artifact for DC/OS OSS.
     """
-    return Path('/tmp/dcos_generate_config.sh')
+    return 'file:///tmp/dcos_generate_config.sh'
 
 
 @pytest.fixture(scope='session')
-def enterprise_artifact() -> Path:
+def enterprise_artifact() -> str:
     """
-    Return the path to an artifact for DC/OS Enterprise.
+    Return the url to a local artifact for DC/OS Enterprise.
     """
-    return Path('/tmp/dcos_generate_config.ee.sh')
+    return 'file:///tmp/dcos_generate_config.ee.sh'
+
+
+@pytest.fixture(scope='session')
+def oss_artifact_url() -> str:
+    """
+    Return the url to a for DC/OS Enterprise artifact on a HTTPS server.
+    """
+    return 'https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh'

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -22,7 +22,7 @@ class TestEnterpriseIntegrationTests:
     def test_run_pytest(
         self,
         cluster_backend: ClusterBackend,
-        enterprise_artifact: Path,
+        enterprise_artifact: str,
     ) -> None:
         """
         Integration tests can be run with `pytest`.
@@ -36,7 +36,7 @@ class TestEnterpriseIntegrationTests:
         }
 
         with Cluster(
-            generate_config_path=enterprise_artifact,
+            generate_config_url=enterprise_artifact,
             cluster_backend=cluster_backend,
             extra_config=extra_config,
             log_output_live=True,
@@ -59,7 +59,7 @@ class TestCopyFiles:
     def test_copy_files_to_installer(
         self,
         cluster_backend: ClusterBackend,
-        enterprise_artifact: Path,
+        enterprise_artifact: str,
     ) -> None:
         """
         Files can be copied from the host to the installer node at creation
@@ -102,7 +102,7 @@ class TestCopyFiles:
         with Cluster(
             cluster_backend=cluster_backend,
             extra_config=config,
-            generate_config_path=enterprise_artifact,
+            generate_config_url=enterprise_artifact,
             files_to_copy_to_installer=files_to_copy_to_installer,
             log_output_live=True,
             masters=1,
@@ -133,7 +133,7 @@ class TestWaitForDCOS:
     def test_auth_with_cli(
         self,
         cluster_backend: ClusterBackend,
-        enterprise_artifact: Path,
+        enterprise_artifact: str,
     ) -> None:
         """
         After `Cluster.wait_for_dcos`, the cluster can communicate with the
@@ -149,7 +149,7 @@ class TestWaitForDCOS:
         }
 
         with Cluster(
-            generate_config_path=enterprise_artifact,
+            generate_config_url=enterprise_artifact,
             cluster_backend=cluster_backend,
             extra_config=extra_config,
             log_output_live=True,

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -6,7 +6,6 @@ long time to run.
 """
 
 import logging
-from pathlib import Path
 from subprocess import CalledProcessError
 from typing import List
 
@@ -23,9 +22,7 @@ class TestIntegrationTests:
     """
 
     def test_run_pytest(
-        self,
-        cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        self, cluster_backend: ClusterBackend, oss_artifact: str
     ) -> None:
         """
         Integration tests can be run with `pytest`.
@@ -33,7 +30,7 @@ class TestIntegrationTests:
         """
         with Cluster(
             cluster_backend=cluster_backend,
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             log_output_live=True,
         ) as cluster:
             # No error is raised with a successful command.
@@ -73,7 +70,7 @@ class TestExtendConfig:
         self,
         path: str,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         This example demonstrates that it is possible to create a cluster
@@ -94,7 +91,7 @@ class TestExtendConfig:
         }
 
         with Cluster(
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             extra_config=config,
             agents=0,
             public_agents=0,
@@ -108,7 +105,7 @@ class TestExtendConfig:
         self,
         path: str,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         The example file does not exist with the standard configuration.
@@ -116,7 +113,7 @@ class TestExtendConfig:
         configuration.
         """
         with Cluster(
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             agents=0,
             public_agents=0,
             cluster_backend=cluster_backend,
@@ -133,7 +130,7 @@ class TestClusterSize:
     """
 
     def test_default(
-        self, cluster_backend: ClusterBackend, oss_artifact: Path
+        self, cluster_backend: ClusterBackend, oss_artifact: str
     ) -> None:
         """
         By default, a cluster with one master and one agent and one private
@@ -141,7 +138,7 @@ class TestClusterSize:
         """
         with Cluster(
             cluster_backend=cluster_backend,
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
         ) as cluster:
             assert len(cluster.masters) == 1
             assert len(cluster.agents) == 1
@@ -150,7 +147,7 @@ class TestClusterSize:
     def test_custom(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         It is possible to create a cluster with a custom number of nodes.
@@ -164,7 +161,7 @@ class TestClusterSize:
         public_agents = 2
 
         with Cluster(
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             masters=masters,
             agents=agents,
             public_agents=public_agents,
@@ -207,7 +204,7 @@ class TestClusterLogging:
         self,
         caplog: CompatLogCaptureFixture,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         If `log_output_live` is given as `True`, subprocess output is logged.
@@ -215,7 +212,7 @@ class TestClusterLogging:
         with pytest.raises(CalledProcessError):
             # It is not possible to create a cluster with two master nodes.
             with Cluster(
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
                 masters=2,
                 log_output_live=True,
                 cluster_backend=cluster_backend
@@ -228,7 +225,7 @@ class TestClusterLogging:
         self,
         caplog: CompatLogCaptureFixture,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         By default, subprocess output is not logged in the creation of a
@@ -239,7 +236,7 @@ class TestClusterLogging:
             with Cluster(
                 masters=2,
                 cluster_backend=cluster_backend,
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
             ):
                 pass  # pragma: no cover
 
@@ -254,7 +251,7 @@ class TestMultipleClusters:
     def test_two_clusters(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         It is possible to start two clusters.
@@ -265,11 +262,11 @@ class TestMultipleClusters:
         """
         with Cluster(
             cluster_backend=cluster_backend,
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
         ):
             with Cluster(
                 cluster_backend=cluster_backend,
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
             ):
                 pass
 
@@ -282,14 +279,14 @@ class TestDestroyOnError:
     def test_default_exception_raised(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         By default, if an exception is raised, the cluster is destroyed.
         """
         with pytest.raises(Exception):
             with Cluster(
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
                 agents=0,
                 public_agents=0,
                 cluster_backend=cluster_backend,
@@ -304,7 +301,7 @@ class TestDestroyOnError:
     def test_set_false_exception_raised(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         If `destroy_on_error` is set to `False` and an exception is raised,
@@ -312,7 +309,7 @@ class TestDestroyOnError:
         """
         with pytest.raises(Exception):
             with Cluster(
-                generate_config_path=oss_artifact,
+                generate_config_url=oss_artifact,
                 agents=0,
                 public_agents=0,
                 destroy_on_error=False,
@@ -334,13 +331,13 @@ class TestDestroyOnSuccess:
     def test_default(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         By default the cluster is destroyed if there is no exception raised.
         """
         with Cluster(
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             agents=0,
             public_agents=0,
             cluster_backend=cluster_backend,
@@ -354,14 +351,14 @@ class TestDestroyOnSuccess:
     def test_false(
         self,
         cluster_backend: ClusterBackend,
-        oss_artifact: Path,
+        oss_artifact: str,
     ) -> None:
         """
         If `destroy_on_success` is set to `False`, the cluster is
         preserved if there is no exception raised.
         """
         with Cluster(
-            generate_config_path=oss_artifact,
+            generate_config_url=oss_artifact,
             agents=0,
             public_agents=0,
             cluster_backend=cluster_backend,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -23,7 +23,7 @@ from dcos_e2e.cluster import Cluster
 
 @pytest.fixture(scope='module')
 def dcos_cluster(
-    oss_artifact: Path,
+    oss_artifact: str,
     cluster_backend: ClusterBackend,
 ) -> Iterator[Cluster]:
     """
@@ -34,7 +34,7 @@ def dcos_cluster(
     """
     with Cluster(
         cluster_backend=cluster_backend,
-        generate_config_path=oss_artifact,
+        generate_config_url=oss_artifact,
         masters=1,
         agents=0,
         public_agents=0,


### PR DESCRIPTION
In order to support the DC/OS advanced installation method which requires the build artifact to reside on a HTTP(S) server we need to allow for artifacts being passed to DC/OS E2E by url.
The documentation of any cluster backend must specify which url schemes it will accept.