### PR TITLE
[WIP] default ssh user

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,13 +26,13 @@
     - [`masters`](#masters-1)
     - [`agents`](#agents-1)
     - [`public_agents`](#public_agents-1)
+    - [`default_ssh_user`](#default_ssh_user)
 - [`dcos_e2e.node.Node`](#dcos_e2enodenode)
   - [Parameters](#parameters-1)
     - [`ip_address`](#ip_address)
     - [`ssh_key_path`](#ssh_key_path)
   - [Methods](#methods-1)
     - [`node.run(args, user, log_output_live=False, env=None)`](#noderunargs-user-log_output_livefalse-envnone)
-    - [`node.run_as_root(args, log_output_live=False, env=None)`](#noderun_as_rootargs-log_output_livefalse-envnone)
     - [`node.popen(args, user, env=None) -> Popen`](#nodepopenargs-user-envnone---popen)
     - [`node.send_file(local_path, remote_path) -> None`](#nodesend_filelocal_path-remote_path---none)
   - [Attributes](#attributes-1)
@@ -153,6 +153,10 @@ The agent nodes in the cluster.
 
 The public agent nodes in the cluster.
 
+#### `default_ssh_user`
+
+The default SSH user to access cluster nodes.
+
 ## `dcos_e2e.node.Node`
 
 Commands can be run on nodes in clusters.
@@ -169,22 +173,13 @@ The IP address of the node.
 
 #### `ssh_key_path`
 
-The path to an SSH key which can be used to SSH to the node as the `root` user.
+The path to an SSH key which can be used to SSH to the node as the clusters `default_ssh_user` user.
 
 ### Methods
 
 #### `node.run(args, user, log_output_live=False, env=None)`
 
 `user` specifies the user that the given command will be run for over SSH.
-
-If `log_output_live` is set to `True`, the output of processes run on the host to create and manage clusters will be logged.
-
-To see these logs in `pytest` tests, use the `-s` flag.
-
-`env` is an optional mapping of environment variable names to values.
-These environment variables will be set on the node before running the command specified in `args`.
-
-#### `node.run_as_root(args, log_output_live=False, env=None)`
 
 If `log_output_live` is set to `True`, the output of processes run on the host to create and manage clusters will be logged.
 

--- a/API.md
+++ b/API.md
@@ -173,7 +173,7 @@ The IP address of the node.
 
 #### `ssh_key_path`
 
-The path to an SSH key which can be used to SSH to the node as the clusters `default_ssh_user` user.
+The path to an SSH key which can be used to SSH to the node as the cluster's `default_ssh_user` user.
 
 ### Methods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 * Backwards incompatible change: Replace `generate_config_path` with `build_artifact`
 that can either be a `Path` or a HTTP(S) URL string. This allows for supporting installation
 methods that require build artifacts to be downloaded from a HTTP server.
+* Backwards incompatible change: Remove `run_as_root`. Instead require a `default_ssh_user`
+for backends to `run` commands over SSH on any cluster `Node` created with this backend.
 
 ## 2017.11.02.0
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ class TestExample:
             build_artifact=Path('/tmp/dcos_generate_config.sh'),
         ) as cluster:
             (master, ) = cluster.masters
-            result = master.run_as_root(args=['test', '-f', path])
+            result = master.run(args=['test', '-f', path],
+                                user=cluster.default_ssh_user)
             print(result.stdout)
             cluster.run_integration_tests(pytest_command=['pytest', '-x', 'test_tls.py'])
             try:
-                master.run_as_root(args=['test', '-f', '/no/file/here'])
+                master.run(args=['test', '-f', '/no/file/here'],
+                           user=cluster.default_ssh_user)
             except subprocess.CalledProcessError:
                 print('No file exists')
 ```

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -19,8 +19,8 @@ LOGGER = logging.getLogger(__name__)
 def run_subprocess(
     args: List[str],
     log_output_live: bool,
-    cwd: Optional[Union[bytes, str]]=None,
-    env: Optional[Dict[str, str]]=None,
+    cwd: Optional[Union[bytes, str]] = None,
+    env: Optional[Dict[str, str]] = None,
 ) -> CompletedProcess:
     """
     Run a command in a subprocess.

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -19,8 +19,8 @@ LOGGER = logging.getLogger(__name__)
 def run_subprocess(
     args: List[str],
     log_output_live: bool,
-    cwd: Optional[Union[bytes, str]] = None,
-    env: Optional[Dict[str, str]] = None,
+    cwd: Optional[Union[bytes, str]]=None,
+    env: Optional[Dict[str, str]]=None,
 ) -> CompletedProcess:
     """
     Run a command in a subprocess.

--- a/src/dcos_e2e/backends/_base_classes.py
+++ b/src/dcos_e2e/backends/_base_classes.py
@@ -95,3 +95,10 @@ class ClusterBackend(abc.ABC):
         Return whether this backend supports being destroyed with a `destroy`
         method.
         """
+
+    @property
+    @abc.abstractmethod
+    def default_ssh_user(self) -> str:
+        """
+        Return the default SSH user as a string.
+        """

--- a/src/dcos_e2e/backends/_base_classes.py
+++ b/src/dcos_e2e/backends/_base_classes.py
@@ -31,7 +31,7 @@ class ClusterManager(abc.ABC):
 
         Args:
             build_artifact: The `Path` or URL string to a build artifact
-            of DC/OS to install from.
+                of DC/OS to install from.
             masters: The number of master nodes to create.
             agents: The number of agent nodes to create.
             public_agents: The number of public agent nodes to create.

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -91,6 +91,13 @@ class Docker(ClusterBackend):
         """
         return True
 
+    @property
+    def default_ssh_user(self) -> str:
+        """
+        Return `root` as the default SSH user for the Docker backend.
+        """
+        return 'root'
+
 
 class DockerCluster(ClusterManager):
     """
@@ -438,6 +445,8 @@ class DockerCluster(ClusterManager):
                 tmpfs=node_tmpfs_mounts,
             )
 
+        self._default_ssh_user = 'root'
+
         superuser_password = 'admin'
         superuser_password_hash = sha512_crypt.hash(superuser_password)
         config_file_path = genconf_dir / 'config.yaml'
@@ -462,7 +471,7 @@ class DockerCluster(ClusterManager):
             'ssh_port':
             22,
             'ssh_user':
-            'root',
+            self._default_ssh_user,
             'superuser_password_hash':
             superuser_password_hash,
             'superuser_username':
@@ -507,12 +516,18 @@ class DockerCluster(ClusterManager):
             ]
 
             for node in nodes:
-                node.run_as_root(args=dcos_install_args)
+                node.run(
+                    args=dcos_install_args,
+                    user=cluster_backend.default_ssh_user
+                )
 
         for node in {*self.masters, *self.agents, *self.public_agents}:
             # Remove stray file that prevents non-root SSH.
             # https://ubuntuforums.org/showthread.php?t=2327330
-            node.run_as_root(args=['rm', '-f', '/run/nologin'])
+            node.run(
+                args=['rm', '-f', '/run/nologin'],
+                user=cluster_backend.default_ssh_user
+            )
 
     def _start_dcos_container(
         self,

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -445,8 +445,6 @@ class DockerCluster(ClusterManager):
                 tmpfs=node_tmpfs_mounts,
             )
 
-        self._default_ssh_user = 'root'
-
         superuser_password = 'admin'
         superuser_password_hash = sha512_crypt.hash(superuser_password)
         config_file_path = genconf_dir / 'config.yaml'
@@ -471,7 +469,7 @@ class DockerCluster(ClusterManager):
             'ssh_port':
             22,
             'ssh_user':
-            self._default_ssh_user,
+            cluster_backend.default_ssh_user,
             'superuser_password_hash':
             superuser_password_hash,
             'superuser_username':

--- a/src/dcos_e2e/backends/_existing_cluster.py
+++ b/src/dcos_e2e/backends/_existing_cluster.py
@@ -15,8 +15,11 @@ class ExistingCluster(ClusterBackend):
     """
 
     def __init__(
-        self, masters: Set[Node], agents: Set[Node], public_agents: Set[Node],
-        default_ssh_user: str
+        self,
+        masters: Set[Node],
+        agents: Set[Node],
+        public_agents: Set[Node],
+        default_ssh_user: str,
     ) -> None:
         """
         Create a record of an existing cluster backend for use by a cluster

--- a/src/dcos_e2e/backends/_existing_cluster.py
+++ b/src/dcos_e2e/backends/_existing_cluster.py
@@ -15,10 +15,8 @@ class ExistingCluster(ClusterBackend):
     """
 
     def __init__(
-        self,
-        masters: Set[Node],
-        agents: Set[Node],
-        public_agents: Set[Node],
+        self, masters: Set[Node], agents: Set[Node], public_agents: Set[Node],
+        default_ssh_user: str
     ) -> None:
         """
         Create a record of an existing cluster backend for use by a cluster
@@ -27,6 +25,7 @@ class ExistingCluster(ClusterBackend):
         self.masters = masters
         self.agents = agents
         self.public_agents = public_agents
+        self._default_ssh_user = default_ssh_user
 
     @property
     def cluster_cls(self) -> Type['ExistingClusterManager']:
@@ -42,6 +41,13 @@ class ExistingCluster(ClusterBackend):
         Destroying an existing cluster is the responsibility of the caller.
         """
         return False
+
+    @property
+    def default_ssh_user(self) -> str:
+        """
+        Return the default SSH user for this backend.
+        """
+        return self._default_ssh_user
 
 
 class ExistingClusterManager(ClusterManager):

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -28,15 +28,15 @@ class Cluster(ContextDecorator):
     def __init__(
         self,
         cluster_backend: ClusterBackend,
-        build_artifact: Union[str, Path]=None,
-        extra_config: Optional[Dict[str, Any]]=None,
-        masters: int=1,
-        agents: int=1,
-        public_agents: int=1,
-        log_output_live: bool=False,
-        destroy_on_error: bool=True,
-        destroy_on_success: bool=True,
-        files_to_copy_to_installer: Optional[Dict[Path, Path]]=None,
+        build_artifact: Union[str, Path] = None,
+        extra_config: Optional[Dict[str, Any]] = None,
+        masters: int = 1,
+        agents: int = 1,
+        public_agents: int = 1,
+        log_output_live: bool = False,
+        destroy_on_error: bool = True,
+        destroy_on_success: bool = True,
+        files_to_copy_to_installer: Optional[Dict[Path, Path]] = None,
     ) -> None:
         """
         Create a DC/OS cluster.
@@ -188,7 +188,7 @@ class Cluster(ContextDecorator):
     def run_integration_tests(
         self,
         pytest_command: List[str],
-        env: Optional[Dict]=None,
+        env: Optional[Dict] = None,
     ) -> subprocess.CompletedProcess:
         """
         Run integration tests on a random master node.

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -28,15 +28,15 @@ class Cluster(ContextDecorator):
     def __init__(
         self,
         cluster_backend: ClusterBackend,
-        build_artifact: Union[str, Path] = None,
-        extra_config: Optional[Dict[str, Any]] = None,
-        masters: int = 1,
-        agents: int = 1,
-        public_agents: int = 1,
-        log_output_live: bool = False,
-        destroy_on_error: bool = True,
-        destroy_on_success: bool = True,
-        files_to_copy_to_installer: Optional[Dict[Path, Path]] = None,
+        build_artifact: Union[str, Path]=None,
+        extra_config: Optional[Dict[str, Any]]=None,
+        masters: int=1,
+        agents: int=1,
+        public_agents: int=1,
+        log_output_live: bool=False,
+        destroy_on_error: bool=True,
+        destroy_on_success: bool=True,
+        files_to_copy_to_installer: Optional[Dict[Path, Path]]=None,
     ) -> None:
         """
         Create a DC/OS cluster.
@@ -109,6 +109,7 @@ class Cluster(ContextDecorator):
         """
         Wait until DC/OS has started and all nodes have joined the cluster.
         """
+
         diagnostics_args = [
             '/opt/mesosphere/bin/dcos-diagnostics',
             '--diag',
@@ -117,13 +118,10 @@ class Cluster(ContextDecorator):
             '--diag',
         ]
 
-        # Must be run privileged
-        if not self.default_ssh_user == 'root':
-            diagnostics_args = ['sudo'] + diagnostics_args
-
         for node in self.masters:
             node.run(
                 args=diagnostics_args,
+                # Keep in mind this must be run as privileged user.
                 user=self.default_ssh_user,
                 log_output_live=self._log_output_live,
                 env={
@@ -190,7 +188,7 @@ class Cluster(ContextDecorator):
     def run_integration_tests(
         self,
         pytest_command: List[str],
-        env: Optional[Dict] = None,
+        env: Optional[Dict]=None,
     ) -> subprocess.CompletedProcess:
         """
         Run integration tests on a random master node.

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -35,7 +35,7 @@ class Node:
         self,
         args: List[str],
         user: str,
-        env: Optional[Dict]=None,
+        env: Optional[Dict] = None,
     ) -> List[str]:
         """
         Return a command to run `args` on this node over SSH.
@@ -94,8 +94,8 @@ class Node:
         self,
         args: List[str],
         user: str,
-        log_output_live: bool=False,
-        env: Optional[Dict]=None,
+        log_output_live: bool = False,
+        env: Optional[Dict] = None,
     ) -> CompletedProcess:
         """
         Run a command on this node the given user.
@@ -122,7 +122,7 @@ class Node:
         self,
         args: List[str],
         user: str,
-        env: Optional[Dict]=None,
+        env: Optional[Dict] = None,
     ) -> Popen:
         """
         Open a pipe to a command run on a node as the given user.

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -35,7 +35,7 @@ class Node:
         self,
         args: List[str],
         user: str,
-        env: Optional[Dict] = None,
+        env: Optional[Dict]=None,
     ) -> List[str]:
         """
         Return a command to run `args` on this node over SSH.
@@ -94,8 +94,8 @@ class Node:
         self,
         args: List[str],
         user: str,
-        log_output_live: bool = False,
-        env: Optional[Dict] = None,
+        log_output_live: bool=False,
+        env: Optional[Dict]=None,
     ) -> CompletedProcess:
         """
         Run a command on this node the given user.
@@ -122,7 +122,7 @@ class Node:
         self,
         args: List[str],
         user: str,
-        env: Optional[Dict] = None,
+        env: Optional[Dict]=None,
     ) -> Popen:
         """
         Open a pipe to a command run on a node as the given user.

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -118,37 +118,6 @@ class Node:
         ssh_args = self._compose_ssh_command(args=args, user=user, env=env)
         return run_subprocess(args=ssh_args, log_output_live=log_output_live)
 
-    def run_as_root(
-        self,
-        args: List[str],
-        log_output_live: bool = False,
-        env: Optional[Dict] = None,
-    ) -> CompletedProcess:
-        """
-        Run a command on this node as `root`.
-
-        Args:
-            args: The command to run on the node.
-            log_output_live: If `True`, log output live. If `True`, stderr is
-                merged into stdout in the return value.
-            env: Environment variables to be set on the node before running
-                the command. A mapping of environment variable names to
-                values.
-
-        Returns:
-            The representation of the finished process.
-
-        Raises:
-            CalledProcessError: The process exited with a non-zero code.
-        """
-
-        return self.run(
-            args=args,
-            user='root',
-            log_output_live=log_output_live,
-            env=env,
-        )
-
     def popen(
         self,
         args: List[str],

--- a/tests/backends/test_docker.py
+++ b/tests/backends/test_docker.py
@@ -48,12 +48,12 @@ class TestCustomMasterMounts:
         ) as cluster:
             (master, ) = cluster.masters
             args = ['cat', str(master_path)]
-            result = master.run_as_root(args=args)
+            result = master.run(args=args, user=cluster.default_ssh_user)
             assert result.stdout.decode() == content
 
             new_content = str(uuid.uuid4())
             local_file.write(new_content)
-            result = master.run_as_root(args=args)
+            result = master.run(args=args, user=cluster.default_ssh_user)
             assert result.stdout.decode() == new_content
 
 

--- a/tests/backends/test_existing_cluster.py
+++ b/tests/backends/test_existing_cluster.py
@@ -21,8 +21,9 @@ class TestExistingCluster:
         It is possible to create a cluster from existing nodes, but not destroy
         it.
         """
+        backend = Docker()
         with Cluster(
-            cluster_backend=Docker(),
+            cluster_backend=backend,
             build_artifact=oss_artifact,
             masters=1,
             agents=1,
@@ -37,6 +38,7 @@ class TestExistingCluster:
                 masters=cluster.masters,
                 agents=cluster.agents,
                 public_agents=cluster.public_agents,
+                default_ssh_user=backend.default_ssh_user
             )
 
             with Cluster(
@@ -52,24 +54,29 @@ class TestExistingCluster:
                 (duplicate_public_agent, ) = duplicate_cluster.public_agents
 
                 duplicate_master.run(
-                    args=['touch', 'example_master_file'], user='root'
+                    args=['touch', 'example_master_file'],
+                    user=duplicate_cluster.default_ssh_user
                 )
                 duplicate_agent.run(
-                    args=['touch', 'example_agent_file'], user='root'
+                    args=['touch', 'example_agent_file'],
+                    user=duplicate_cluster.default_ssh_user
                 )
                 duplicate_public_agent.run(
-                    args=['touch', 'example_public_agent_file'], user='root'
+                    args=['touch', 'example_public_agent_file'],
+                    user=duplicate_cluster.default_ssh_user
                 )
 
                 master.run(
-                    args=['test', '-f', 'example_master_file'], user='root'
+                    args=['test', '-f', 'example_master_file'],
+                    user=duplicate_cluster.default_ssh_user
                 )
                 agent.run(
-                    args=['test', '-f', 'example_agent_file'], user='root'
+                    args=['test', '-f', 'example_agent_file'],
+                    user=duplicate_cluster.default_ssh_user
                 )
                 public_agent.run(
                     args=['test', '-f', 'example_public_agent_file'],
-                    user='root'
+                    user=duplicate_cluster.default_ssh_user
                 )
 
             with pytest.raises(NotImplementedError):
@@ -110,6 +117,7 @@ class TestBadParameters:
             masters=dcos_cluster.masters,
             agents=dcos_cluster.agents,
             public_agents=dcos_cluster.public_agents,
+            default_ssh_user=dcos_cluster.default_ssh_user
         )
 
     def test_destroy_on_error(

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -100,7 +100,9 @@ class TestExtendConfig:
         ) as cluster:
             cluster.wait_for_dcos()
             (master, ) = cluster.masters
-            master.run_as_root(args=['test', '-f', path])
+            master.run(
+                args=['test', '-f', path], user=cluster.default_ssh_user
+            )
 
     def test_default_config(
         self,
@@ -122,7 +124,9 @@ class TestExtendConfig:
             (master, ) = cluster.masters
             cluster.wait_for_dcos()
             with pytest.raises(CalledProcessError):
-                master.run_as_root(args=['test', '-f', path])
+                master.run(
+                    args=['test', '-f', path], user=cluster.default_ssh_user
+                )
 
 
 class TestClusterSize:
@@ -297,7 +301,7 @@ class TestDestroyOnError:
                 raise Exception()
 
         with pytest.raises(CalledProcessError):
-            master.run_as_root(args=['echo', 'hello'])
+            master.run(args=['echo', 'hello'], user=cluster.default_ssh_user)
 
     def test_set_false_exception_raised(
         self,
@@ -320,7 +324,11 @@ class TestDestroyOnError:
                 cluster.wait_for_dcos()
                 raise Exception()
         # No exception is raised. The node still exists.
-        master.run_as_root(args=['echo', 'hello'], log_output_live=True)
+        master.run(
+            args=['echo', 'hello'],
+            log_output_live=True,
+            user=cluster.default_ssh_user
+        )
         cluster.destroy()
 
 
@@ -347,7 +355,7 @@ class TestDestroyOnSuccess:
             (master, ) = cluster.masters
 
         with pytest.raises(CalledProcessError):
-            master.run_as_root(args=['echo', 'hello'])
+            master.run(args=['echo', 'hello'], user=cluster.default_ssh_user)
 
     def test_false(
         self,
@@ -368,5 +376,5 @@ class TestDestroyOnSuccess:
             cluster.wait_for_dcos()
             (master, ) = cluster.masters
 
-        master.run_as_root(args=['echo', 'hello'])
+        master.run(args=['echo', 'hello'], user=cluster.default_ssh_user)
         cluster.destroy()


### PR DESCRIPTION
In order to run commands on cluster nodes that do not have root access over SSH enabled by default a cluster advertises the default SSH user that can be used instead.