### PR TITLE
disable fault domain script by default

### DIFF
--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -500,6 +500,7 @@ class DockerCluster(ClusterManager):
             'resolvers': ['8.8.8.8'],
             'ssh_port': 22,
             'ssh_user': ssh_user,
+            'fault_domain_enabled': 'false',
         }
 
         config_yaml = yaml.dump(data={**config, **extra_config})


### PR DESCRIPTION
fault domain is now a required option in EE DC/OS.
This change disables the fault domains by default, however it is up to the user
to override it from a specific test. If we ever need to test a fault domain
in EE, the user might override this change from extra config.
https://jira.mesosphere.com/browse/DCOS-19702