### PR TITLE
Extend wait for dcos ee timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 
 - [Changelog](#changelog)
+- [Next](#next)
   - [2017.11.29.0](#201711290)
   - [2017.11.21.0](#201711210)
   - [2017.11.15.0](#201711150)
@@ -27,6 +28,10 @@
 <!--lint enable list-item-bullet-indent-->
 
 # Changelog
+
+# Next
+
+* Extend `wait_for_dcos_ee` timeout for waiting until the DC/OS CA cert can be fetched.
 
 ## 2017.11.29.0
 

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -145,10 +145,10 @@ class Cluster(ContextDecorator):
         warnings.simplefilter('ignore', InsecureRequestWarning)
 
         ca_cert = api_session.get(
-            # We wait up to 10 minutes which is arbitrary but has worked
-            # in testing at the time of writing.
+            # We wait up to 30 minutes which is extraordinarily large
+            # but should avoid problems with 3 or 5 master counts.
             '/ca/dcos-ca.crt',
-            retry_timeout=60 * 10,
+            retry_timeout=60 * 30,
             verify=False
         )
         ca_cert.raise_for_status()


### PR DESCRIPTION
Extending wait_for_dcos_ee timeout for waiting until the DC/OS CA cert can be fetched.