### PR TITLE
Bring back dcos-diagnostics check prior to wait_for_dcos_oss/ee

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ PyYAML==3.12
 requests==2.18.4
 retry==0.9.2
 scp==0.10.2
-urllib3==1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ dcos-test-utils==0.1
 docker==2.6.1
 paramiko==2.4.0
 PyYAML==3.12
+requests==2.18.4
+retry==0.9.2
 scp==0.10.2
 urllib3==1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ dcos-test-utils==0.1
 docker==2.6.1
 paramiko==2.4.0
 PyYAML==3.12
-requests==2.18.4
 retry==0.9.2
 scp==0.10.2

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -40,3 +40,6 @@ utils
 username
 vm
 xfail
+sso
+oauth
+zookeeper

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 
 import requests
 from dcos_test_utils.dcos_api import DcosApiSession, DcosUser
+from dcos_test_utils.enterprise import EnterpriseApiSession
 from dcos_test_utils.helpers import CI_CREDENTIALS
 from requests import codes
 from retry import retry
@@ -154,7 +155,7 @@ class Cluster(ContextDecorator):
             RetryError: Raised if any cluster component did not become
                 healthy in time.
         """
-        self._wait_for_adminrouter(log_output_live=True)
+        self._wait_for_adminrouter()
 
         any_master = next(iter(self.masters))
 
@@ -185,7 +186,7 @@ class Cluster(ContextDecorator):
                 healthy in time.
         """
 
-        self._wait_for_adminrouter(log_output_live=True)
+        self._wait_for_adminrouter()
 
         credentials = {
             'uid': superuser_username,
@@ -194,7 +195,7 @@ class Cluster(ContextDecorator):
 
         any_master = next(iter(self.masters))
 
-        api_session = DcosApiSession(
+        enterprise_session = EnterpriseApiSession(
             dcos_url='https://{ip}'.format(ip=any_master.ip_address),
             masters=[str(n.ip_address) for n in self.masters],
             slaves=[str(n.ip_address) for n in self.agents],
@@ -202,8 +203,8 @@ class Cluster(ContextDecorator):
             auth_user=DcosUser(credentials=credentials),
         )
 
-        api_session.set_ca_cert()
-        api_session.wait_for_dcos()
+        enterprise_session.set_ca_cert()
+        enterprise_session.wait_for_dcos()
 
     def __enter__(self) -> 'Cluster':
         """

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -93,7 +93,7 @@ class Cluster(ContextDecorator):
     @retry(
         exceptions=(subprocess.CalledProcessError),
         tries=500,
-        delay=5,
+        delay=10,
     )
     def _wait_for_dcos_diagnostics(self) -> None:
         """
@@ -140,7 +140,7 @@ class Cluster(ContextDecorator):
         # Suggestion for replacing this with a DC/OS check for CLI login:
 
         # Determine and wait for all dependencies of the SSO OAuth login
-        # inside of DC/OS. This should include Admin Router, Zookeeper and
+        # inside of DC/OS. This should include Admin Router, ZooKeeper and
         # the DC/OS OAuth login service. Note that this may only guarantee
         # that the login could work, however not that is actually works.
 

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -98,12 +98,6 @@ class Cluster(ContextDecorator):
     def _wait_for_dcos_diagnostics(self) -> None:
         """
         Wait until all DC/OS systemd units are healthy.
-
-        Args:
-            log_output_live: If `True`, log output of the diagnostics check
-                live. If `True`, stderr is merged into stdout in the return
-                value.
-
         """
         for node in self.masters:
             node.run(

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -95,10 +95,7 @@ class Cluster(ContextDecorator):
         tries=500,
         delay=5,
     )
-    def _wait_for_dcos_diagnostics(
-        self,
-        log_output_live: bool = False,
-    ) -> None:
+    def _wait_for_dcos_diagnostics(self) -> None:
         """
         Wait until all DC/OS systemd units are healthy.
 
@@ -113,7 +110,7 @@ class Cluster(ContextDecorator):
                 args=['/opt/mesosphere/bin/dcos-diagnostics', '--diag'],
                 # Keep in mind this must be run as privileged user.
                 user=self.default_ssh_user,
-                log_output_live=log_output_live,
+                log_output_live=True,
                 env={
                     'LC_ALL': 'en_US.UTF-8',
                     'LANG': 'en_US.UTF-8',
@@ -198,10 +195,10 @@ class Cluster(ContextDecorator):
 
         # Suggestion for replacing this with a DC/OS check for CLI login:
 
-        # In Enterprise
-        # DC/OS this could be replace by polling the login endpoint with
-        # random login credentials until it returns 401. In that case
-        # the guarantees would be the same as with the OSS suggestion.
+        # In Enterprise DC/OS this could be replace by polling the login
+        # endpoint with random login credentials until it returns 401. In
+        # that case the guarantees would be the same as with the OSS
+        # suggestion.
 
         # The progress on a partial replacement can be followed here:
         # https://jira.mesosphere.com/browse/DCOS_OSS-1313


### PR DESCRIPTION
The PR should help to narrow down the wait_for_dcos/ee time to < 5 minutes by re-introducing the dcos-diagnostics check that was carried out in prior version of DC/OS E2E. The arbitrary waiting time after this check was set to 5 minutes back then.