### PR TITLE
Distinguish between host and DC/OS ip address at Node creation

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,14 +33,15 @@
     - [`default_ssh_user`](#default_ssh_user)
 - [`dcos_e2e.node.Node`](#dcos_e2enodenode)
   - [Parameters](#parameters-1)
-    - [`ip_address`](#ip_address)
+    - [`host_ip_address`](#host_ip_address)
+    - [`dcos_ip_address`](#dcos_ip_address)
     - [`ssh_key_path`](#ssh_key_path)
   - [Methods](#methods-1)
     - [`node.run(args, user, log_output_live=False, env=None)`](#noderunargs-user-log_output_livefalse-envnone)
     - [`node.popen(args, user, env=None) -> Popen`](#nodepopenargs-user-envnone---popen)
     - [`node.send_file(local_path, remote_path, user) -> None`](#nodesend_filelocal_path-remote_path-user---none)
   - [Attributes](#attributes-1)
-    - [`ip_address`](#ip_address-1)
+    - [`ip_address`](#ip_address)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!--lint enable list-item-indent-->
@@ -198,14 +199,18 @@ The default SSH user to access cluster nodes.
 Commands can be run on nodes in clusters.
 
 ```python
-Node(ip_address, ssh_key_path)
+Node(host_ip_address, dcos_ip_address, ssh_key_path)
 ```
 
 ### Parameters
 
-#### `ip_address`
+#### `host_ip_address`
 
-The IP address of the node.
+The public IP address of the host represented by this node.
+
+#### `dcos_ip_address`
+
+The IP address that the DC/OS component on this node uses.
 
 #### `ssh_key_path`
 
@@ -241,4 +246,4 @@ Copy a file to the node via SSH as the given user.
 
 #### `ip_address`
 
-The IP address of the node.
+The IP address that the DC/OS component on this node uses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 
 - [Changelog](#changelog)
+- [Next](#next)
 - [2017.12.11.0](#201712110)
 - [2017.12.08.0](#201712080)
   - [2017.11.29.0](#201711290)
@@ -29,6 +30,10 @@
 <!--lint enable list-item-bullet-indent-->
 
 # Changelog
+
+# Next
+
+* Distinguish between host IP for SSH connection and DC/OS IP address when creating a Node.
 
 # 2017.12.11.0
 

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -643,14 +643,19 @@ class DockerCluster(ClusterManager):
         filters = {'name': container_base_name}
         containers = client.containers.list(filters=filters)
 
-        return set(
-            Node(
-                ip_address=IPv4Address(
-                    container.attrs['NetworkSettings']['IPAddress']
-                ),
-                ssh_key_path=self._path / 'include' / 'ssh' / 'id_rsa',
-            ) for container in containers
-        )
+        nodes = set([])
+        for container in containers:
+            ip_address = IPv4Address(
+                container.attrs['NetworkSettings']['IPAddress']
+            )
+            nodes.add(
+                Node(
+                    ip_address=ip_address,
+                    private_ip_address=ip_address,
+                    ssh_key_path=self._path / 'include' / 'ssh' / 'id_rsa',
+                )
+            )
+        return nodes
 
     @property
     def masters(self) -> Set[Node]:

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -645,13 +645,13 @@ class DockerCluster(ClusterManager):
 
         nodes = set([])
         for container in containers:
-            ip_address = IPv4Address(
+            container_ip_address = IPv4Address(
                 container.attrs['NetworkSettings']['IPAddress']
             )
             nodes.add(
                 Node(
-                    ip_address=ip_address,
-                    private_ip_address=ip_address,
+                    host_ip_address=container_ip_address,
+                    dcos_ip_address=container_ip_address,
                     ssh_key_path=self._path / 'include' / 'ssh' / 'id_rsa',
                 )
             )

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -20,23 +20,24 @@ class Node:
 
     def __init__(
         self,
-        ip_address: IPv4Address,
-        private_ip_address: IPv4Address,
+        host_ip_address: IPv4Address,
+        dcos_ip_address: IPv4Address,
         ssh_key_path: Path,
     ) -> None:
         """
         Args:
-            ip_address: The public IP address of the node.
-            private_ip_address: The IP address within a DC/OS cloud
-                deployment's subnet.
+            host_ip_address: The public IP address of the node.
+            dcos_ip_address: The IP address used by the DC/OS component
+                running on this node.
             ssh_key_path: The path to an SSH key which can be used to SSH to
                 the node as the `root` user.
 
         Attributes:
-            ip_address: The IP address of the node.
+            ip_address: The IP address used by the DC/OS component
+                running on this node.
         """
-        self.ip_address = ip_address
-        self.private_ip_address = private_ip_address
+        self.ip_address = dcos_ip_address
+        self._host_ip_address = host_ip_address
         self._ssh_key_path = ssh_key_path
 
     def _compose_ssh_command(
@@ -93,7 +94,7 @@ class Node:
             # Bypass password checking.
             '-o',
             'PreferredAuthentications=publickey',
-            str(self.ip_address),
+            str(self._host_ip_address),
         ] + command
 
         return ssh_args
@@ -166,7 +167,7 @@ class Node:
         ssh_client = paramiko.SSHClient()
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh_client.connect(
-            str(self.ip_address),
+            str(self._host_ip_address),
             username=user,
             key_filename=str(self._ssh_key_path),
         )

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -18,10 +18,17 @@ class Node:
     A record of a DC/OS cluster node.
     """
 
-    def __init__(self, ip_address: IPv4Address, ssh_key_path: Path) -> None:
+    def __init__(
+        self,
+        ip_address: IPv4Address,
+        private_ip_address: IPv4Address,
+        ssh_key_path: Path,
+    ) -> None:
         """
         Args:
-            ip_address: The IP address of the node.
+            ip_address: The public IP address of the node.
+            private_ip_address: The IP address within a DC/OS cloud
+                deployment's subnet.
             ssh_key_path: The path to an SSH key which can be used to SSH to
                 the node as the `root` user.
 
@@ -29,6 +36,7 @@ class Node:
             ip_address: The IP address of the node.
         """
         self.ip_address = ip_address
+        self.private_ip_address = private_ip_address
         self._ssh_key_path = ssh_key_path
 
     def _compose_ssh_command(


### PR DESCRIPTION
In order to support DC/OS cloud deployments with a dedicated subnet for DC/OS masters/agents we introduce the notion of a host and a DC/OS IP address when creating a new Node object. The host IP address is only required for connecting to the host via SSH. Therefore it can be hidden in the Node object. The DC/OS IP address that can be different from the host IP address is exposed as `ip_address` attribute. Universial DC/OS integration tests will only require the DC/OS IP accessible through the API. The host address is a implementation detail of the chosen backend.