### PR TITLE
Expose public and private IP on Node object

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,15 +33,16 @@
     - [`default_ssh_user`](#default_ssh_user)
 - [`dcos_e2e.node.Node`](#dcos_e2enodenode)
   - [Parameters](#parameters-1)
-    - [`host_ip_address`](#host_ip_address)
-    - [`dcos_ip_address`](#dcos_ip_address)
+    - [`public_ip_address`](#public_ip_address)
+    - [`private_ip_address`](#private_ip_address)
     - [`ssh_key_path`](#ssh_key_path)
   - [Methods](#methods-1)
     - [`node.run(args, user, log_output_live=False, env=None)`](#noderunargs-user-log_output_livefalse-envnone)
     - [`node.popen(args, user, env=None) -> Popen`](#nodepopenargs-user-envnone---popen)
     - [`node.send_file(local_path, remote_path, user) -> None`](#nodesend_filelocal_path-remote_path-user---none)
   - [Attributes](#attributes-1)
-    - [`ip_address`](#ip_address)
+    - [`public_ip_address`](#public_ip_address-1)
+    - [`private_ip_address`](#private_ip_address-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!--lint enable list-item-indent-->
@@ -199,16 +200,16 @@ The default SSH user to access cluster nodes.
 Commands can be run on nodes in clusters.
 
 ```python
-Node(host_ip_address, dcos_ip_address, ssh_key_path)
+Node(public_ip_address, private_ip_address, ssh_key_path)
 ```
 
 ### Parameters
 
-#### `host_ip_address`
+#### `public_ip_address`
 
 The public IP address of the host represented by this node.
 
-#### `dcos_ip_address`
+#### `private_ip_address`
 
 The IP address that the DC/OS component on this node uses.
 
@@ -244,6 +245,10 @@ Copy a file to the node via SSH as the given user.
 
 ### Attributes
 
-#### `ip_address`
+#### `public_ip_address`
+
+The public IP address of the host represented by this node.
+
+#### `private_ip_address`
 
 The IP address that the DC/OS component on this node uses.

--- a/BACKENDS.md
+++ b/BACKENDS.md
@@ -63,6 +63,7 @@ See `volumes` in [the `docker-py` documentation](http://docker-py.readthedocs.io
 ### DC/OS Installation
 
 `Cluster`s created by the Docker backend only support installing DC/OS via `install_dcos_from_path`.
+`Node`s of `Cluster`s created by the Docker backend do not distinguish between `public_ip_address` and `private_ip_address`.
 
 ### Troubleshooting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 # Next
 
-* Distinguish between host IP for SSH connection and DC/OS IP address when creating a Node.
+* Expose the `public_ip_address` of the SSH connection and the `private_ip_address` of its DC/OS component on `Node` objects.
 
 # 2017.12.11.0
 

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -479,7 +479,7 @@ class DockerCluster(ClusterManager):
         ssh_user = self._default_ssh_user
 
         def ip_list(nodes: Set[Node]) -> List[str]:
-            return list(map(lambda node: str(node.ip_address), nodes))
+            return list(map(lambda node: str(node.public_ip_address), nodes))
 
         config = {
             'agent_list': ip_list(nodes=self.agents),
@@ -578,7 +578,7 @@ class DockerCluster(ClusterManager):
         registry_host = 'registry.local'
         if self.masters:
             first_master = next(iter(self.masters))
-            extra_host_ip_address = str(first_master.ip_address)
+            extra_host_ip_address = str(first_master.public_ip_address)
         else:
             extra_host_ip_address = '127.0.0.1'
         hostname = container_base_name + str(container_number)
@@ -650,8 +650,8 @@ class DockerCluster(ClusterManager):
             )
             nodes.add(
                 Node(
-                    host_ip_address=container_ip_address,
-                    dcos_ip_address=container_ip_address,
+                    public_ip_address=container_ip_address,
+                    private_ip_address=container_ip_address,
                     ssh_key_path=self._path / 'include' / 'ssh' / 'id_rsa',
                 )
             )

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -150,10 +150,12 @@ class Cluster(ContextDecorator):
         any_master = next(iter(self.masters))
 
         api_session = DcosApiSession(
-            dcos_url='http://{ip}'.format(ip=any_master.ip_address),
-            masters=[str(n.ip_address) for n in self.masters],
-            slaves=[str(n.ip_address) for n in self.agents],
-            public_slaves=[str(n.ip_address) for n in self.public_agents],
+            dcos_url='http://{ip}'.format(ip=any_master.public_ip_address),
+            masters=[str(n.public_ip_address) for n in self.masters],
+            slaves=[str(n.public_ip_address) for n in self.agents],
+            public_slaves=[
+                str(n.public_ip_address) for n in self.public_agents
+            ],
             auth_user=DcosUser(credentials=CI_CREDENTIALS),
         )
 
@@ -208,10 +210,12 @@ class Cluster(ContextDecorator):
         any_master = next(iter(self.masters))
 
         enterprise_session = EnterpriseApiSession(
-            dcos_url='https://{ip}'.format(ip=any_master.ip_address),
-            masters=[str(n.ip_address) for n in self.masters],
-            slaves=[str(n.ip_address) for n in self.agents],
-            public_slaves=[str(n.ip_address) for n in self.public_agents],
+            dcos_url='https://{ip}'.format(ip=any_master.public_ip_address),
+            masters=[str(n.public_ip_address) for n in self.masters],
+            slaves=[str(n.public_ip_address) for n in self.agents],
+            public_slaves=[
+                str(n.public_ip_address) for n in self.public_agents
+            ],
             auth_user=DcosUser(credentials=credentials),
         )
 
@@ -353,7 +357,9 @@ class Cluster(ContextDecorator):
         env = env or {}
 
         def ip_addresses(nodes: Iterable[Node]) -> str:
-            return ','.join(map(lambda node: str(node.ip_address), nodes))
+            return ','.join(
+                map(lambda node: str(node.public_ip_address), nodes)
+            )
 
         environment_variables = {
             'MASTER_HOSTS': ip_addresses(self.masters),

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -20,14 +20,14 @@ class Node:
 
     def __init__(
         self,
-        host_ip_address: IPv4Address,
-        dcos_ip_address: IPv4Address,
+        public_ip_address: IPv4Address,
+        private_ip_address: IPv4Address,
         ssh_key_path: Path,
     ) -> None:
         """
         Args:
-            host_ip_address: The public IP address of the node.
-            dcos_ip_address: The IP address used by the DC/OS component
+            public_ip_address: The public IP address of the node.
+            private_ip_address: The IP address used by the DC/OS component
                 running on this node.
             ssh_key_path: The path to an SSH key which can be used to SSH to
                 the node as the `root` user.
@@ -36,8 +36,8 @@ class Node:
             ip_address: The IP address used by the DC/OS component
                 running on this node.
         """
-        self.ip_address = dcos_ip_address
-        self._host_ip_address = host_ip_address
+        self.public_ip_address = public_ip_address
+        self.private_ip_address = private_ip_address
         self._ssh_key_path = ssh_key_path
 
     def _compose_ssh_command(
@@ -94,7 +94,7 @@ class Node:
             # Bypass password checking.
             '-o',
             'PreferredAuthentications=publickey',
-            str(self._host_ip_address),
+            str(self.public_ip_address),
         ] + command
 
         return ssh_args
@@ -167,7 +167,7 @@ class Node:
         ssh_client = paramiko.SSHClient()
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh_client.connect(
-            str(self._host_ip_address),
+            str(self.public_ip_address),
             username=user,
             key_filename=str(self._ssh_key_path),
         )

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -131,7 +131,7 @@ class TestCopyFiles:
                 superuser_username=superuser_username,
                 superuser_password=superuser_password,
             )
-            master_url = 'https://' + str(master.ip_address)
+            master_url = 'https://' + str(master.public_ip_address)
             response = requests.get(master_url, verify=str(cert_path))
             response.raise_for_status()
 
@@ -175,7 +175,7 @@ class TestWaitForDCOS:
                 'dcos',
                 'cluster',
                 'setup',
-                'https://' + str(master.ip_address),
+                'https://' + str(master.public_ip_address),
                 '--no-check',
                 '--username',
                 superuser_username,


### PR DESCRIPTION
Recently the interface of the `Node` object was changed to take `host_ip_address` (public ip in DC/OS terms) and `dcos_ip_address` (private ip in DC/OS terms). `Node` then exposed only an `ip_address` attribute which is equivalent to `dcos_ip_address`.

The problem with this approach is that the DC/OS CLI setup requires the public ip to be readily available. Therefore we change the interface in such a way that the backend writer as well as the test writer must be aware of the types of ip addresses used within the DC/OS deployment method tied to a given backend. The `Node` object now exposes both, `public_ip_addess` and `private_ip_address`.