### PR TITLE
[DCOS-20471] Escape shell commands

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,8 +37,8 @@
     - [`private_ip_address`](#private_ip_address)
     - [`ssh_key_path`](#ssh_key_path)
   - [Methods](#methods-1)
-    - [`node.run(args, user, log_output_live=False, env=None)`](#noderunargs-user-log_output_livefalse-envnone)
-    - [`node.popen(args, user, env=None) -> Popen`](#nodepopenargs-user-envnone---popen)
+    - [`node.run(args, user, log_output_live=False, env=None, shell=False) -> CompletedProcess`](#noderunargs-user-log_output_livefalse-envnone-shellfalse---completedprocess)
+    - [`node.popen(args, user, env=None, shell=False) -> Popen`](#nodepopenargs-user-envnone-shellfalse---popen)
     - [`node.send_file(local_path, remote_path, user) -> None`](#nodesend_filelocal_path-remote_path-user---none)
   - [Attributes](#attributes-1)
     - [`public_ip_address`](#public_ip_address-1)
@@ -219,7 +219,7 @@ The path to an SSH key which can be used to SSH to the node as the cluster's `de
 
 ### Methods
 
-#### `node.run(args, user, log_output_live=False, env=None)`
+#### `node.run(args, user, log_output_live=False, env=None, shell=False) -> CompletedProcess`
 
 `user` specifies the user that the given command will be run for over SSH.
 
@@ -230,12 +230,22 @@ To see these logs in `pytest` tests, use the `-s` flag.
 `env` is an optional mapping of environment variable names to values.
 These environment variables will be set on the node before running the command specified in `args`.
 
-#### `node.popen(args, user, env=None) -> Popen`
+`shell` is a boolean controlling whether the command args should be interpreted as a sequence of literals or as parts of a shell command.
+If `shell=False` (the default), each argument is passed as a literal value to the command.
+If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. $, &&, >).
+This means the caller must quote arguments if they may contain these special characters, including whitespace.
+
+#### `node.popen(args, user, env=None, shell=False) -> Popen`
 
 `user` specifies the user that the given command will be run for over SSH.
 
 `env` is an optional mapping of environment variable names to values.
 These environment variables will be set on the node before running the command specified in `args`.
+
+`shell` is a boolean controlling whether the command args should be interpreted as a sequence of literals or as parts of a shell command.
+If `shell=False` (the default), each argument is passed as a literal value to the command.
+If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. $, &&, >).
+This means the caller must quote arguments if they may contain these special characters, including whitespace.
 
 The method returns a `Popen` object that can be used to communicate to the underlying subprocess.
 

--- a/API.md
+++ b/API.md
@@ -232,7 +232,7 @@ These environment variables will be set on the node before running the command s
 
 `shell` is a boolean controlling whether the command args should be interpreted as a sequence of literals or as parts of a shell command.
 If `shell=False` (the default), each argument is passed as a literal value to the command.
-If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. $, &&, >).
+If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. `$`, `&&`, `>`).
 This means the caller must quote arguments if they may contain these special characters, including whitespace.
 
 #### `node.popen(args, user, env=None, shell=False) -> Popen`
@@ -244,7 +244,7 @@ These environment variables will be set on the node before running the command s
 
 `shell` is a boolean controlling whether the command args should be interpreted as a sequence of literals or as parts of a shell command.
 If `shell=False` (the default), each argument is passed as a literal value to the command.
-If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. $, &&, >).
+If `shell=True`, the command line is interpreted as a shell command, with a special meaning applied to some characters (e.g. `$`, `&&`, `>`).
 This means the caller must quote arguments if they may contain these special characters, including whitespace.
 
 The method returns a `Popen` object that can be used to communicate to the underlying subprocess.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 # Next
 
 * Add custom string representation for `Node` object.
+* Change the default behavior of `Node.run` and `Node.popen` to quote arguments, unless a new `shell` parameter is `True`.
+These methods now behave similarly to `subprocess.run`.
 
 # 2018.01.22.0
 

--- a/src/dcos_e2e/cluster.py
+++ b/src/dcos_e2e/cluster.py
@@ -378,6 +378,7 @@ class Cluster(ContextDecorator):
             user=self.default_ssh_user,
             log_output_live=log_output_live,
             env=environment_variables,
+            shell=True,
         )
 
     def destroy(self) -> None:

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -2,7 +2,6 @@
 Tools for managing DC/OS cluster nodes.
 """
 
-import itertools
 from ipaddress import IPv4Address
 from pathlib import Path
 from shlex import quote
@@ -58,6 +57,7 @@ class Node:
         args: List[str],
         user: str,
         env: Optional[Dict] = None,
+        shell: bool = False,
     ) -> List[str]:
         """
         Return a command to run `args` on this node over SSH.
@@ -68,18 +68,20 @@ class Node:
             env: Environment variables to be set on the node before running
                 the command. A mapping of environment variable names to
                 values.
+            shell: If False (the default), each argument is passed as a
+                literal value to the command.  If True, the command line is
+                interpreted as a shell command, with a special meaning applied
+                to some characters (e.g. $, &&, >). This means the caller must
+                quote arguments if they may contain these special characters,
+                including whitespace.
 
         Returns:
             The full SSH command to be run.
         """
         env = dict(env or {})
 
-        # The remote command line arguments must be quoted to ensure
-        # they create the right arguments on the remote node.
-        command = [quote(s) for s in itertools.chain(
-            ('{key}={value}'.format(key=k, value=v) for k, v in env.items()),
-            args
-        )]
+        if shell:
+            args = ['/bin/sh', '-c', ' '.join(args)]
 
         ssh_args = [
             'ssh',
@@ -106,7 +108,10 @@ class Node:
             '-o',
             'PreferredAuthentications=publickey',
             str(self.public_ip_address),
-        ] + command
+        ] + [
+            '{key}={value}'.format(key=k, value=quote(v))
+            for k, v in env.items()
+        ] + [quote(arg) for arg in args]
 
         return ssh_args
 
@@ -116,6 +121,7 @@ class Node:
         user: str,
         log_output_live: bool = False,
         env: Optional[Dict] = None,
+        shell: bool = False,
     ) -> CompletedProcess:
         """
         Run a command on this node the given user.
@@ -128,6 +134,12 @@ class Node:
             env: Environment variables to be set on the node before running
                 the command. A mapping of environment variable names to
                 values.
+            shell: If False (the default), each argument is passed as a
+                literal value to the command.  If True, the command line is
+                interpreted as a shell command, with a special meaning applied
+                to some characters (e.g. $, &&, >). This means the caller must
+                quote arguments if they may contain these special characters,
+                including whitespace.
 
         Returns:
             The representation of the finished process.
@@ -135,7 +147,9 @@ class Node:
         Raises:
             CalledProcessError: The process exited with a non-zero code.
         """
-        ssh_args = self._compose_ssh_command(args=args, user=user, env=env)
+        ssh_args = self._compose_ssh_command(
+            args=args, user=user, env=env, shell=shell
+        )
         return run_subprocess(args=ssh_args, log_output_live=log_output_live)
 
     def popen(
@@ -143,6 +157,7 @@ class Node:
         args: List[str],
         user: str,
         env: Optional[Dict] = None,
+        shell: bool = False,
     ) -> Popen:
         """
         Open a pipe to a command run on a node as the given user.
@@ -153,11 +168,19 @@ class Node:
             env: Environment variables to be set on the node before running
                 the command. A mapping of environment variable names to
                 values.
+            shell: If False (the default), each argument is passed as a
+                literal value to the command.  If True, the command line is
+                interpreted as a shell command, with a special meaning applied
+                to some characters (e.g. $, &&, >). This means the caller must
+                quote arguments if they may contain these special characters,
+                including whitespace.
 
         Returns:
             The pipe object attached to the specified process.
         """
-        ssh_args = self._compose_ssh_command(args=args, user=user, env=env)
+        ssh_args = self._compose_ssh_command(
+            args=args, user=user, env=env, shell=shell
+        )
         return Popen(args=ssh_args, stdout=PIPE, stderr=PIPE)
 
     def send_file(

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -2,8 +2,10 @@
 Tools for managing DC/OS cluster nodes.
 """
 
+import itertools
 from ipaddress import IPv4Address
 from pathlib import Path
+from shlex import quote
 from subprocess import PIPE, CompletedProcess, Popen
 from typing import Dict, List, Optional
 
@@ -72,14 +74,12 @@ class Node:
         """
         env = dict(env or {})
 
-        command = []
-
-        for key, value in env.items():
-            export = "export {key}='{value}'".format(key=key, value=value)
-            command.append(export)
-            command.append('&&')
-
-        command += args
+        # The remote command line arguments must be quoted to ensure
+        # they create the right arguments on the remote node.
+        command = [quote(s) for s in itertools.chain(
+            ('{key}={value}'.format(key=k, value=v) for k, v in env.items()),
+            args
+        )]
 
         ssh_args = [
             'ssh',


### PR DESCRIPTION
Escape shell commands in the `Node.run` and `Node.popen` methods.  This means that passing 'hello world' in the list of args will be interpreted as a single argument on the remote node, rather than as two arguments separated by a space. This mimics the behavior of Python's `subprocess` module.

This is a better default because tests are typically written using simple parameters, and pass fine. Eventually a real value gets used that has a special character and something breaks, by now usually deep down in multiple layers of code.  On the other hand, when special characters are meant to be interpreted as special characters, tests break quickly, and a solution is identified.

To provide that solution, a `shell` parameter has been added, similar to the `subprocess` parameter. This provides behavior more like the old behavior, with spaces and other special characters being interpreted using shell semantics. The main difference is that the `Node` methods still expect a list of strings, and do not accept a plain string.

The `dcos-enterprise` `test-e2e` tests all use literal values, so will not break with these changes. The only exception is the test that I have in a Pull Request, which will need to be changed when this is added.  However, I am not sure whether this e2e code is used anywhere else?