### PR TITLE
Node string representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 
 - [Changelog](#changelog)
+- [Next](#next)
 - [2018.01.22.0](#201801220)
 - [2017.12.11.0](#201712110)
 - [2017.12.08.0](#201712080)
@@ -30,6 +31,10 @@
 <!--lint enable list-item-bullet-indent-->
 
 # Changelog
+
+# Next
+
+* Add custom string representation for `Node` object.
 
 # 2018.01.22.0
 

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -41,7 +41,11 @@ class Node:
         self._ssh_key_path = ssh_key_path
 
     def __str__(self) -> str:
-        """Convert a `Node` object to string listing its IP addresses."""
+        """
+        Convert a `Node` object to string listing only its IP addresses.
+
+        Returns the custom string representation of a `Node` object.
+        """
         return 'Node(public_ip={public_ip}, private_ip={private_ip})'.format(
             public_ip=self.public_ip_address,
             private_ip=self.private_ip_address,

--- a/src/dcos_e2e/node.py
+++ b/src/dcos_e2e/node.py
@@ -40,6 +40,13 @@ class Node:
         self.private_ip_address = private_ip_address
         self._ssh_key_path = ssh_key_path
 
+    def __str__(self) -> str:
+        """Convert a `Node` object to string listing its IP addresses."""
+        return 'Node(public_ip={public_ip}, private_ip={private_ip})'.format(
+            public_ip=self.public_ip_address,
+            private_ip=self.private_ip_address,
+        )
+
     def _compose_ssh_command(
         self,
         args: List[str],

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -156,3 +156,17 @@ class TestNode:
         args = ['cat', str(master_destination_path)]
         result = master.run(args=args, user=dcos_cluster.default_ssh_user)
         assert result.stdout.decode() == content
+
+    def test_string_representation(
+        self,
+        dcos_cluster: Cluster,
+    ) -> None:
+        """
+        The string representation has the expected format.
+        """
+        (master, ) = dcos_cluster.masters
+        string = 'Node(public_ip={public_ip}, private_ip={private_ip})'.format(
+            public_ip=master.public_ip_address,
+            private_ip=master.private_ip_address,
+        )
+        assert string == str(master)


### PR DESCRIPTION
This PR adds a custom `string` representation for the `Node` object, listing the corresponding `public_ip_address` and `private_ip_address`.