### PR TITLE
[DCOS-20920] Remove noise from command logging

### DIFF
--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -78,7 +78,7 @@ def run_subprocess(
         if stderr:
             if retcode == 0:
                 log = LOGGER.warning
-                log(args)
+                log(repr(args))
             else:
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -58,7 +58,7 @@ def run_subprocess(
                 stdout = b''
                 stderr = b''
                 for line in process.stdout:
-                    LOGGER.debug(line)
+                    LOGGER.debug(line.rstrip().decode('ascii', 'backslashreplace'))
                     stdout += line
                 # Without this, `.poll()` will return None on some
                 # systems.
@@ -73,8 +73,15 @@ def run_subprocess(
             process.wait()
             raise
         retcode = process.poll()
+        if stderr:
+            if retcode == 0:
+                log = LOGGER.warning
+                log(args)
+            else:
+                log = LOGGER.error
+            for line in stderr.rstrip().split(b'\n'):
+                log(line.rstrip().decode('ascii', 'backslashreplace'))
         if retcode > 0:
-            LOGGER.info(str(stderr))
             raise CalledProcessError(
                 retcode, args, output=stdout, stderr=stderr
             )

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -58,7 +58,9 @@ def run_subprocess(
                 stdout = b''
                 stderr = b''
                 for line in process.stdout:
-                    LOGGER.debug(line.rstrip().decode('ascii', 'backslashreplace'))
+                    LOGGER.debug(
+                        line.rstrip().decode('ascii', 'backslashreplace')
+                    )
                     stdout += line
                 # Without this, `.poll()` will return None on some
                 # systems.


### PR DESCRIPTION
The logging from `dcos-e2e._common` is noisy, with `b'...\n'` around each log and an extra layer of escapes. Safely convert the command output from bytestrings to strings so that the logs are more readable. In addition, `stderr` is output even when the return code is 0, so we can identify any potential problems with code.

Without this patch:
```
$ pytest -s tests/test_node.py::TestNode::test_run_literal 2>&1 | grep _common | tail -10
DEBUG:dcos_e2e._common:b'  "user_arguments":"{\\n  \\"agent_list\\":\\"[]\\",\\n  \\"bootstrap_url\\":\\"file:///opt/dcos_install_tmp\\",\\n  \\"check_time\\":\\"false\\",\\n  \\"cluster_name\\":\\"DCOS\\",\\n  \\"exhibitor_storage_backend\\":\\"static\\",\\n  \\"master_discovery\\":\\"static\\",\\n  \\"master_list\\":\\"[\\\\\\"172.17.0.3\\\\\\"]\\",\\n  \\"process_timeout\\":\\"10000\\",\\n  \\"public_agent_list\\":\\"[]\\",\\n  \\"resolvers\\":\\"[\\\\\\"8.8.8.8\\\\\\"]\\",\\n  \\"ssh_port\\":\\"22\\",\\n  \\"ssh_user\\":\\"root\\"\\n}",\n'
DEBUG:dcos_e2e._common:b'  "user_arguments_full":"**HIDDEN**",\n'
DEBUG:dcos_e2e._common:b'  "weights":""\n'
DEBUG:dcos_e2e._common:b'}\n'
DEBUG:dcos_e2e._common:b'validating template file dcos-config.yaml\n'
DEBUG:dcos_e2e._common:b'validating template file dcos-metadata.yaml\n'
DEBUG:dcos_e2e._common:b'Cluster package list: package_lists/dd50a78d70b790c87582ec855141ce7a809656bb.package_list.json\n'
DEBUG:dcos_e2e._common:b'Package filename: packages/dcos-config/dcos-config--setup_d2d22a07c3bdd6f674bfdc215a77fdf674aa79ad.tar.xz\n'
DEBUG:dcos_e2e._common:b'Package filename: packages/dcos-metadata/dcos-metadata--setup_d2d22a07c3bdd6f674bfdc215a77fdf674aa79ad.tar.xz\n'
DEBUG:dcos_e2e._common:b'Generating Bash configuration files for DC/OS\n'

```

With this patch:
```
pytest -s tests/test_node.py::TestNode::test_run_literal 2>&1 | grep _common | tail -15
DEBUG:dcos_e2e._common:  "user_arguments":"{\n  \"agent_list\":\"[]\",\n  \"bootstrap_url\":\"file:///opt/dcos_install_tmp\",\n  \"check_time\":\"false\",\n  \"cluster_name\":\"DCOS\",\n  \"exhibitor_storage_backend\":\"static\",\n  \"master_discovery\":\"static\",\n  \"master_list\":\"[\\\"172.17.0.3\\\"]\",\n  \"process_timeout\":\"10000\",\n  \"public_agent_list\":\"[]\",\n  \"resolvers\":\"[\\\"8.8.8.8\\\"]\",\n  \"ssh_port\":\"22\",\n  \"ssh_user\":\"root\"\n}",
DEBUG:dcos_e2e._common:  "user_arguments_full":"**HIDDEN**",
DEBUG:dcos_e2e._common:  "weights":""
DEBUG:dcos_e2e._common:}
DEBUG:dcos_e2e._common:validating template file dcos-config.yaml
DEBUG:dcos_e2e._common:validating template file dcos-metadata.yaml
DEBUG:dcos_e2e._common:Cluster package list: package_lists/dd50a78d70b790c87582ec855141ce7a809656bb.package_list.json
DEBUG:dcos_e2e._common:Package filename: packages/dcos-config/dcos-config--setup_d2d22a07c3bdd6f674bfdc215a77fdf674aa79ad.tar.xz
DEBUG:dcos_e2e._common:Package filename: packages/dcos-metadata/dcos-metadata--setup_d2d22a07c3bdd6f674bfdc215a77fdf674aa79ad.tar.xz
DEBUG:dcos_e2e._common:Generating Bash configuration files for DC/OS
WARNING:dcos_e2e._common:['ssh', '-q', '-o', 'IdentitiesOnly=yes', '-o', 'StrictHostKeyChecking=no', '-i', '/tmp/7c6bdcb41d4e4b8981cf19ef31de39f9/dcos-e2e-1c3fbfa1-1fa2-4241-bc44-edffda12e372/include/ssh/id_rsa', '-l', 'root', '-o', 'PreferredAuthentications=publickey', '172.17.0.3', '/bin/bash', '/opt/dcos_install_tmp/dcos_install.sh', '--no-block-dcos-setup', 'master']
WARNING:dcos_e2e._common:WARNING: No swap limit support
WARNING:dcos_e2e._common:WARNING: bridge-nf-call-iptables is disabled
WARNING:dcos_e2e._common:WARNING: bridge-nf-call-ip6tables is disabled
WARNING:dcos_e2e._common:Created symlink from /etc/systemd/system/multi-user.target.wants/dcos-setup.service to /etc/systemd/system/dcos-setup.service.
```

Notice that the first line goes from a peak of 6 backslashes to 3 backslashes, making the actual escaped value more obvious.

Also, the final command demonstrates a warning that may be useful, even though it does not fail.