### PR TITLE
Consolidate child process handling code

### DIFF
--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -64,7 +64,7 @@ def run_subprocess(
                     stdout += line
                 # stderr/stdout are not readable anymore which usually means
                 # that the child process has exited. However, the child
-                # process has not been wait()et for yet, i.e. it has not yet
+                # process has not been wait()ed for yet, i.e. it has not yet
                 # been reaped. That is, its exit status is unknown. Read its
                 # exit status.
                 process.wait()

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -84,7 +84,7 @@ def run_subprocess(
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):
                 log(line.rstrip().decode('ascii', 'backslashreplace'))
-        if process.returncode > 0:
+        if process.returncode != 0:
             raise CalledProcessError(
                 process.returncode, args, output=stdout, stderr=stderr
             )

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -62,10 +62,12 @@ def run_subprocess(
                         line.rstrip().decode('ascii', 'backslashreplace')
                     )
                     stdout += line
-                # Without this, `.poll()` will return None on some
-                # systems.
-                # See https://stackoverflow.com/a/33563376.
-                process.communicate()
+                # stderr/stdout are not readable anymore which usually means
+                # that the child process has exited. However, the child
+                # process has not been wait()et for yet, i.e. it has not yet
+                # been reaped. That is, its exit status is unknown. Read its
+                # exit status.
+                process.wait()
             else:
                 stdout, stderr = process.communicate()
         except:  # noqa: B001 pragma: no cover
@@ -74,17 +76,16 @@ def run_subprocess(
             process.kill()
             process.wait()
             raise
-        retcode = process.poll()
         if stderr:
-            if retcode == 0:
+            if process.returncode == 0:
                 log = LOGGER.warning
                 log(repr(args))
             else:
                 log = LOGGER.error
             for line in stderr.rstrip().split(b'\n'):
                 log(line.rstrip().decode('ascii', 'backslashreplace'))
-        if retcode > 0:
+        if process.returncode > 0:
             raise CalledProcessError(
-                retcode, args, output=stdout, stderr=stderr
+                process.returncode, args, output=stdout, stderr=stderr
             )
-    return CompletedProcess(args, retcode, stdout, stderr)
+    return CompletedProcess(args, process.returncode, stdout, stderr)


### PR DESCRIPTION
This is no functional improvement, the code works as-is, but for a different reason that originally intended / commented. This attempts to make the code more expressive and correct.

Commit message:

```
`communciate()` calls `wait()` behind the scenes, but only
`wait()` is actually what is required here to populate
the `process.returncode` object (the `wait()` system call
is doing exactly that: wait for process termination and
reap the zombie state and read the exit status). With that
change `poll()` is not actually required because the exit
status is known to be known.
```

I am throwing this over the fence a bit, let's discuss on Slack if desired :-).