### PR TITLE
[DCOS_OSS-2177] Add instructions for deploying on Windows, with supporting Vagrantfile

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,4 +35,61 @@ The latest release is |release|.
 
     pip install git+https://github.com/mesosphere/dcos-e2e.git@master
 
+
+Windows
+~~~~~~~
+
+The only supported way to run DC/OS E2E on Windows is using Vagrant and VirtualBox.
+
+- Ensure Virtualization and VT-X support is enabled in your PC's BIOS.
+- Disable Hyper-V virtualisation.
+- Install VirtualBox and VirtualBox Extension Pack.
+- Install Vagrant.
+- Install the Vagrant plugin for persistent disks:
+
+.. code:: ps1
+
+    vagrant plugin install vagrant-persistent-storage
+
+- Optionally install the Vagrant plugins to cache package downloads and keep guest additions updates:
+
+.. code:: ps1
+
+        vagrant plugin install vagrant-cachier
+        vagrant plugin install vagrant-vbguest
+
+- Start Powershell and download the E2E ``Vagrantfile`` to a directory containing a DC/OS installer file:
+
+.. code:: ps1
+
+    ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/mesosphere/dcos-e2e/master/vagrant/Vagrantfile')) | Set-Content -LiteralPath Vagrantfile
+
+- Start the virtual machine and login:
+
+.. code:: ps1
+
+    vagrant up
+    vagrant ssh
+
+You can now run ``dcos-docker`` commands.
+
+To connect to the cluster nodes from the Windows host (e.g. to use the DC/OS web interface), in PowerShell Run as Administrator, and add the Virtual Machine as a gateway:
+
+.. code:: ps1
+
+    route add 172.17.0.0 MASK 255.255.0.0 192.168.18.2
+
+To shutdown, logout of the virtual machine shell, and destroy the virtual machine and disk
+
+.. code:: ps1
+
+    vagrant destroy
+
+The route will be removed on reboot. You can manually remove the route in PowerShell Run as Administrator using:
+
+.. code:: ps1
+
+    route delete 172.17.0.0
+
+
 .. _Homebrew: https://brew.sh

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+# Provisioning script to install Docker and dcos-e2e
+$provision_script = <<SCRIPT
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail -x
+
+# Docker CE installation instructions
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+apt-key fingerprint 0EBFCD88 | grep -c Docker
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update
+apt-get install -y docker-ce=17.12.0~ce-0~ubuntu
+
+# Allow user to run Docker commands
+usermod -a -G docker ubuntu
+
+# Install dcos-e2e
+apt-get install -y python3-pip
+pip3 install git+https://github.com/mesosphere/dcos-e2e.git@master
+
+# Accept IP forwarding to Docker containers.  On the VM host, set this VM guest's IP (192.168.18.2)
+# as the gateway for routing 172.17.0.0/16.  This allows the VM host to connect to Docker containers,
+# to use the DC/OS web interface, for example.
+iptables -I DOCKER-USER ! -i docker0 -o docker0 -j ACCEPT
+SCRIPT
+
+# Provisioning script to start user in /vagrant directory
+$user_script = <<SCRIPT
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail -x
+
+grep -q 'cd /vagrant' ~/.bash_profile || echo -e '\n[ -d /vagrant ] && cd /vagrant' >> ~/.bash_profile
+SCRIPT
+
+unless Vagrant.has_plugin?("vagrant-persistent-storage")
+  raise 'Please run "vagrant plugin install vagrant-persistent-storage" first'
+end
+
+Vagrant.configure("2") do |config|
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+  if Vagrant.has_plugin?('vagrant-vbguest')
+    config.vbguest.auto_update = true
+  end
+
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.network "private_network", ip: "192.168.18.2"
+
+  config.vm.provider :virtualbox do |vbox|
+    vbox.name = "dcos-e2e"
+    vbox.cpus = 2
+    vbox.memory = 10240
+  end
+
+  unless ARGV[0] == "destroy"
+    # Add a large disk for Docker volumes.
+    # The persistent-storage plugin keeps disks on vagrant destroy.
+    # Hide this stanza on `destroy` to ensure disk is destroyed.
+    config.persistent_storage.enabled = true
+    config.persistent_storage.location = "vagrant-disk.vdi"
+    config.persistent_storage.size = 50 * 1024  # 50 GiB
+    config.persistent_storage.mountname = 'docker'
+    config.persistent_storage.filesystem = 'ext4'
+    config.persistent_storage.mountpoint = '/var/lib/docker'
+    config.persistent_storage.diskdevice = '/dev/sdc'
+  end
+
+  config.vm.provision "shell", inline: $provision_script
+
+  config.vm.provision "shell", inline: $user_script, privileged: false
+end


### PR DESCRIPTION
Add instructions for running DC/OS E2E on Windows.  The only way we could get it to work was using Vagrant.  This works similarly to `dcos-docker`'s Vagrant setup, but I have rewritten it to use Ubuntu 16.04. Because Ubuntu is generally more up-to-date than CentOS, it is simpler to install Python 3.5 and newer versions of Docker.

Having the Docker build in this repo means the users have to wait for the VM software to install, but it also provides the flexibility to change the setup. I've also tried to explain why everything is in there, to avoid any "magic that just makes it work".

The description for the Windows installation is applicable to Mac and Linux as well. Just needs different commands to download the Vagrantfile and to setup the routing.