### PR TITLE
base-docker:  fix 17.12.1-ce dockerfile

### DIFF
--- a/src/dcos_e2e/backends/_docker/resources/dockerfiles/base-docker/17.12.1-ce/Dockerfile
+++ b/src/dcos_e2e/backends/_docker/resources/dockerfiles/base-docker/17.12.1-ce/Dockerfile
@@ -6,10 +6,10 @@ ENV LANG en_US.UTF-8
 
 # install dind and docker
 RUN curl -sSL --fail "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" | tar xvzf - -C /usr/bin/ --strip 1 \
-	&& curl -sSL --fail "https://raw.githubusercontent.com/docker/docker/v17.12.1-ce/contrib/completion/bash/docker" -o /etc/bash_completion.d/docker \
+	&& curl -sSL --fail "https://raw.githubusercontent.com/docker/docker-ce/17.12/components/cli/contrib/completion/bash/docker" -o /etc/bash_completion.d/docker \
 	&& chmod +x /usr/bin/docker* \
-	&& groupadd -r nogroup || true \
-	&& groupadd -r docker || true \
+	&& groupadd -r nogroup \
+	&& groupadd -r docker \
 	&& gpasswd -a "root" docker || true \
 	&& rm -f /etc/securetty \
 	&& ln -vf /bin/true /usr/sbin/modprobe \


### PR DESCRIPTION
The curl was failing with 404 Not Found, causing the entire RUN instruction to fail.