### PR TITLE
Aws backend dcos 1.9 workaround

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Next
 ----
 
+- The AWS backend now supports DC/OS 1.9.
+
 2018.04.11.0
 ------------
 

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -182,9 +182,8 @@ class AWSCluster(ClusterManager):
         # dcos-launch config to pass the config validation step.
         launch_config['dcos_config'] = {
             'cluster_name': unique,
-            'resolvers': ['8.8.4.4', '8.8.8.8'],
+            'resolvers': ['10.10.0.2', '8.8.8.8'],
             'master_discovery': 'static',
-            'dns_search': 'mesos',
             'exhibitor_storage_backend': 'static',
             'ip_detect_public_contents': detect_ip_public,
         }

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -170,7 +170,7 @@ class AWSCluster(ClusterManager):
             'provider': 'onprem',
         }
 
-        # Workaround for < 1.9.8 where ``ip_detect_public_filename`` is ignored.
+        # Workaround ``ip_detect_public_filename`` being is ignored.
         # https://jira.mesosphere.com/browse/DCOS-21960
         detect_ip_public = (
             '"#!/bin/bash\\n '

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -170,7 +170,7 @@ class AWSCluster(ClusterManager):
             'provider': 'onprem',
         }
 
-        # Workaround ``ip_detect_public_filename`` being is ignored.
+        # Work around ``ip_detect_public_filename`` being ignored.
         # https://jira.mesosphere.com/browse/DCOS-21960
         detect_ip_public = (
             '"#!/bin/bash\\n '
@@ -237,7 +237,6 @@ class AWSCluster(ClusterManager):
                 configuration of the AWS backend.
             log_output_live: If ``True``, log output of the installation live.
         """
-
         # In order to install DC/OS with the preliminary dcos-launch
         # config the ``build_artifact`` URL is overwritten.
         self.launcher.config['installer_url'] = build_artifact

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -152,15 +152,7 @@ class AWSCluster(ClusterManager):
             Distribution.COREOS: 'coreos',
         }
 
-        # Workaround for 1.9 as it will not work with ip_detect_public_filename
-        # https://jira.mesosphere.com/browse/DCOS-21960
-        detect_ip_public = (
-            '#!/bin/bash\n'
-            'curl fsSL http://169.254.169.254/latest/meta-data/public-ipv4',
-        )
-
         launch_config = {
-            'ip_detect_public_contents': detect_ip_public,
             'admin_location': cluster_backend.admin_location,
             'aws_region': cluster_backend.aws_region,
             'deployment_name': unique,
@@ -178,6 +170,10 @@ class AWSCluster(ClusterManager):
             'provider': 'onprem',
         }
 
+        # Workaround for 1.9 as it will not work with ip_detect_public_filename
+        # https://jira.mesosphere.com/browse/DCOS-21960
+        detect_ip_public = '#!/bin/bash\ncurl fsSL http://169.254.169.254/latest/meta-data/public-ipv4'
+
         # First we create a preliminary dcos-config inside the
         # dcos-launch config to pass the config validation step.
         launch_config['dcos_config'] = {
@@ -186,6 +182,7 @@ class AWSCluster(ClusterManager):
             'master_discovery': 'static',
             'dns_search': 'mesos',
             'exhibitor_storage_backend': 'static',
+            'ip_detect_public_contents': detect_ip_public.encode(),
         }
 
         # Validate the preliminary dcos-launch config.

--- a/src/dcos_e2e/backends/_aws/__init__.py
+++ b/src/dcos_e2e/backends/_aws/__init__.py
@@ -170,9 +170,13 @@ class AWSCluster(ClusterManager):
             'provider': 'onprem',
         }
 
-        # Workaround for 1.9 as it will not work with ip_detect_public_filename
+        # Workaround for < 1.9.8 where ``ip_detect_public_filename`` is ignored.
         # https://jira.mesosphere.com/browse/DCOS-21960
-        detect_ip_public = '#!/bin/bash\ncurl fsSL http://169.254.169.254/latest/meta-data/public-ipv4'
+        detect_ip_public = (
+            '"#!/bin/bash\\n '
+            'curl -fsSL '
+            'http://169.254.169.254/latest/meta-data/public-ipv4"'
+        )
 
         # First we create a preliminary dcos-config inside the
         # dcos-launch config to pass the config validation step.
@@ -182,7 +186,7 @@ class AWSCluster(ClusterManager):
             'master_discovery': 'static',
             'dns_search': 'mesos',
             'exhibitor_storage_backend': 'static',
-            'ip_detect_public_contents': detect_ip_public.encode(),
+            'ip_detect_public_contents': detect_ip_public,
         }
 
         # Validate the preliminary dcos-launch config.


### PR DESCRIPTION
Workaround for the 1.9 bug described here: [DCOS_OSS-847](https://jira.mesosphere.com/browse/DCOS_OSS-847)

Due to a bug in < 1.9.7 `ip_detect_public_filename` has no effect when supplied in the `config.yaml`.
Another unintended behavior, overwriting `ip_detect_public_contents` with a functioning `ip-detect-public` script, can work around this issue until the bug fix is merged into 1.9.8. The workaround also enables us to launch DC/OS < 1.9.7 after the fix was merged. If then the other unintended behavior is fixed someday, and `ip_detect_public_contents` it may not work anymore, because dcos-launch does not add `ip_detect_public_filename` automatically with its pre-defined script if `ip_detect_public_contents` is present. Then we need to take action to differentiate DC/OS versions or remove the workaround and stop supporting < 1.9.7.