### PR TITLE
Set the log level specifically for the log_output_live logger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Next
 ----
 
+- Logs from dependencies are no longer emitted.
 - The AWS backend now supports DC/OS 1.9.
 
 2018.04.11.0

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -36,6 +36,7 @@ homebrew
 hwclock
 init
 ip
+lastResort
 linting
 linuxbrew
 login

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -21,7 +21,7 @@ def get_logger(name: str) -> logging.Logger:
     """
     # This gets the root logger with a ``logging.lastResort``
     # StreamHandler that logs on WARNING level.
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger(name)
 
     # Do this if a logger is called for the first time
     if not logger.hasHandlers():

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -19,25 +19,28 @@ def get_logger(name: str) -> logging.Logger:
     Returns:
         See :py:class:`logging.Logger`.
     """
-
     # This gets the root logger with a ``logging.lastResort``
     # StreamHandler that logs on WARNING level.
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
+    logger = logging.getLogger(__name__)
 
-    # Add a new StreamHandler that logs on DEBUG level in order
-    # to override the ``logging.lastResort`` handler.
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.DEBUG)
+    # Do this if a logger is called for the first time
+    if not logger.hasHandlers():
+        logger.setLevel(logging.DEBUG)
 
-    # Take control of the logging format
-    formatter = logging.Formatter(
-        fmt='%(asctime)s %(levelname)-8s %(name)s | %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-    )
-    handler.setFormatter(formatter)
+        # Add a new StreamHandler that logs on DEBUG level in order
+        # to override the ``logging.lastResort`` handler.
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
 
-    logger.addHandler(handler)
+        # Take control of the logging format
+        formatter = logging.Formatter(
+            fmt='%(asctime)s %(levelname)-8s %(name)s | %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+        )
+        handler.setFormatter(formatter)
+
+        logger.addHandler(handler)
+
     return logger
 
 

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -7,8 +7,8 @@ import subprocess
 from subprocess import PIPE, STDOUT, CompletedProcess, Popen
 from typing import Dict, List, Optional, Union
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
 
 
 def run_subprocess(

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -22,24 +22,21 @@ def get_logger(name: str) -> logging.Logger:
     # This gets the root logger with a ``logging.lastResort``
     # StreamHandler that logs on WARNING level.
     logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
 
-    # Do this if a logger is called for the first time
-    if not logger.hasHandlers():
-        logger.setLevel(logging.DEBUG)
+    # Add a new StreamHandler that logs on DEBUG level in order
+    # to override the ``logging.lastResort`` handler.
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
 
-        # Add a new StreamHandler that logs on DEBUG level in order
-        # to override the ``logging.lastResort`` handler.
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
+    # Take control of the logging format
+    formatter = logging.Formatter(
+        fmt='%(asctime)s %(levelname)-8s %(name)s | %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+    handler.setFormatter(formatter)
 
-        # Take control of the logging format
-        formatter = logging.Formatter(
-            fmt='%(asctime)s %(levelname)-8s %(name)s | %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S',
-        )
-        handler.setFormatter(formatter)
-
-        logger.addHandler(handler)
+    logger.addHandler(handler)
 
     return logger
 

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -7,8 +7,41 @@ import subprocess
 from subprocess import PIPE, STDOUT, CompletedProcess, Popen
 from typing import Dict, List, Optional, Union
 
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.DEBUG)
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Return a customized logger that is able to log on DEBUG level.
+
+    Args:
+        name: Name of the logger. Setting this to ``__name__`` will log
+            the path to the file where the logger has been created.
+
+    Returns:
+        See :py:class:`logging.Logger`.
+    """
+
+    # This gets the root logger with a ``logging.lastResort``
+    # StreamHandler that logs on WARNING level.
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+
+    # Add a new StreamHandler that logs on DEBUG level in order
+    # to override the ``logging.lastResort`` handler.
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+
+    # Take control of the logging format
+    formatter = logging.Formatter(
+        fmt='%(asctime)s %(levelname)-8s %(name)s | %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+    return logger
+
+
+LOGGER = get_logger(__name__)
 
 
 def run_subprocess(

--- a/src/dcos_e2e/_common.py
+++ b/src/dcos_e2e/_common.py
@@ -37,7 +37,6 @@ def get_logger(name: str) -> logging.Logger:
     handler.setFormatter(formatter)
 
     logger.addHandler(handler)
-
     return logger
 
 

--- a/src/dcos_e2e/backends/_docker/__init__.py
+++ b/src/dcos_e2e/backends/_docker/__init__.py
@@ -3,7 +3,6 @@ Helpers for creating and interacting with clusters on Docker.
 """
 
 import inspect
-import logging
 import os
 import socket
 import subprocess
@@ -20,7 +19,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from dcos_e2e._common import run_subprocess
+from dcos_e2e._common import get_logger, run_subprocess
 from dcos_e2e.backends._base_classes import ClusterBackend, ClusterManager
 from dcos_e2e.distributions import Distribution
 from dcos_e2e.docker_storage_drivers import DockerStorageDriver
@@ -30,8 +29,7 @@ from dcos_e2e.node import Node
 from ._containers import start_dcos_container
 from ._docker_build import build_docker_image
 
-logging.basicConfig(level=logging.DEBUG)
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(__name__)
 
 
 def _write_key_pair(public_key_path: Path, private_key_path: Path) -> None:


### PR DESCRIPTION
This change sets the log level to DEBUG specifically for the `LOGGER` that is used to log the live output.
This avoids affecting other loggers by not requiring to modify the `logging.basicConfig`.